### PR TITLE
Fix for 'ReferenceError' in expectHeader* methods

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -339,7 +339,7 @@ Frisby.prototype.expectHeader = function(header, content) {
     if(typeof self.current.response.headers[header] !== "undefined") {
       expect(self.current.response.headers[header].toLowerCase()).toEqual(content.toLowerCase());
     } else {
-      fail("Header '" + header.toLowerCase() + "' not present in HTTP response");
+      throw new Error("Header '" + header + "' not present in HTTP response");
     }
   });
   return this;
@@ -353,7 +353,7 @@ Frisby.prototype.expectHeaderContains = function(header, content) {
     if(typeof self.current.response.headers[header] !== "undefined") {
       expect(self.current.response.headers[header].toLowerCase()).toContain(content.toLowerCase());
     } else {
-      fail("Header '" + header.toLowerCase() + "' not present in HTTP response");
+      throw new Error("Header '" + header + "' not present in HTTP response");
     }
   });
   return this;
@@ -366,7 +366,7 @@ Frisby.prototype.expectBodyContains = function(content) {
     if(typeof self.current.response.body !== "undefined") {
       expect(self.current.response.body).toContain(content);
     } else {
-      fail("No HTTP response body was present or HTTP response was empty");
+      throw new Error("No HTTP response body was present or HTTP response was empty");
     }
   });
   return this;


### PR DESCRIPTION
- Frisby was trying to call the "fail" method from Jasmine in 3 places. The "fail" method has been replaced with "throw new Error" so it should now be fixed.
- I have also removed the toLowerCase() method in these error messages
