### PR TITLE
Added the ability to loop over objects using an & segment marker.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -404,6 +404,13 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
           if("array" !== jt) {
             throw new TypeError("Expected '" + path + "' to be Array (got '" + jt + "' from JSON response)");
           }
+        } else if("&" === segment) {
+          var jt = _toType(jsonBody);
+          type = segment;
+
+          if("object" !== jt) {
+            throw new TypeError("Expected '" + path + "' to be Object (got '" + jt + "' from JSON response)");
+          }
         } else {
           jsonBody = jsonBody[segment];
           var jt = _toType(jsonBody);
@@ -417,7 +424,7 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
     }
 
     // EACH item in array should match
-    if("*" === type) {
+    if("*" === type || "&" === type) {
       _.each(jsonBody, function(json) {
         expect(json).toContainJsonTypes(jsonTest);
       });
@@ -477,6 +484,13 @@ Frisby.prototype.expectJSON = function(jsonTest) {
           if("array" !== jt) {
             throw new TypeError("Expected '" + path + "' to be Array (got '" + jt + "' from JSON response)");
           }
+        } else if("&" === segment) {
+          var jt = _toType(jsonBody);
+          type = segment;
+
+          if("object" !== jt) {
+            throw new TypeError("Expected '" + path + "' to be Object (got '" + jt + "' from JSON response)");
+          }
         } else {
           jsonBody = jsonBody[segment];
           var jt = _toType(jsonBody);
@@ -490,7 +504,7 @@ Frisby.prototype.expectJSON = function(jsonTest) {
     }
 
     // EACH item in array should match
-    if("*" === type) {
+    if("*" === type || "&" === type) {
       _.each(jsonBody, function(json) {
         expect(json).toContainJson(jsonTest);
       });


### PR DESCRIPTION
I added the ability to loop over keyed objects using an & to parse objects like the following:

``` javascript
{ status: 'success',
  message: null,
  result: 
   { '1': 
      { book_id: 1,
        archive_code: 'db_balle_f09',
        author: 'Troupe, Thomas Kingsley',
        illustrator: 'Heyworth, Heather',
        title: 'If I Were a Ballerina',
        title_short: 'If I Were a Ballerina',
        avg_review: 2.7642 },
     '2': 
      { book_id: 2,
        archive_code: 'db_cowb_s10',
        author: 'Braun, Eric',
        illustrator: 'Reid, Mick',
        title: 'If I Were a Cowboy',
        title_short: 'If I Were a Cowboy',
        avg_review: 2.5965 },
     '3': 
      { book_id: 3,
        archive_code: 'db_ffigh_s10',
        author: 'Troupe, Thomas Kingsley',
        illustrator: 'Reid, Mick',
        title: 'If I Were a Firefighter',
        title_short: 'If I Were a Firefighter',
        avg_review: 2.6156 } } }
```

Using an `expectJSON` and `expectJSONTypes` of the following syntax:

``` javascript
.expectJSONTypes('result.&', {
    book_id: String,
    archive_code: String,
    author: String,
    illustrator: String,
    title: String,
    title_short: String,
    avg_review: Number
})
```
