### PR TITLE
Support the ability to specify the raw request body.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -230,7 +230,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       outgoing = {
         json: params.json || false,
         uri: null,
-        body: null,
+        body: params.body || null,
         method: 'GET',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'

--- a/spec/frisby_httpbin_spec.js
+++ b/spec/frisby_httpbin_spec.js
@@ -26,4 +26,36 @@ describe('Frisby live running httpbin tests', function() {
 
   });
 
+  it('should POST raw body content', function() {
+    frisby.create(this.description)
+      .post('http://httpbin.org/post', null, {
+          body: "<?xml version=\"1.0\"?><foo bar=\"baz\"/>\n"
+      })
+      .addHeader('Content-Type', 'application/xml')
+      .expectStatus(200)
+      .expectJSON({
+        data: "<?xml version=\"1.0\"?><foo bar=\"baz\"/>\n",
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      })
+    .toss();
+  });
+
+  it('should PUT raw body content', function() {
+    frisby.create(this.description)
+      .put('http://httpbin.org/put', null, {
+          body: "<?xml version=\"1.0\"?><foo bar=\"baz\"/>\n"
+      })
+      .addHeader('Content-Type', 'application/xml')
+      .expectStatus(200)
+      .expectJSON({
+        data: "<?xml version=\"1.0\"?><foo bar=\"baz\"/>\n",
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      })
+    .toss();
+  });
+
 });


### PR DESCRIPTION
This pull request provides the ability to pass in a `body` property as part of the `.post()` or `.put()` params object, which will be added to the `outgoing.body` property. If no `body` property is provided, then `outgoing.body` defaults to `null`.
