### PR TITLE
Correct Case Sensitivity for HTTP methods

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -194,28 +194,28 @@ Frisby.prototype.auth = function(user, pass) {
 Frisby.prototype.get = function (/* [uri, params] */) {
   var args = Array.prototype.slice.call(arguments);
   args.splice(1, -1, null);
-  return this._request.apply(this, ['get'].concat(args));
+  return this._request.apply(this, ['GET'].concat(args));
 };
 
 Frisby.prototype.post = function (/* [uri, data, params] */) {
   var args = Array.prototype.slice.call(arguments);
-  return this._request.apply(this, ['post'].concat(args));
+  return this._request.apply(this, ['POST'].concat(args));
 };
 
 Frisby.prototype.put = function (/* [uri, data, params] */) {
   var args = Array.prototype.slice.call(arguments);
-  return this._request.apply(this, ['put'].concat(args));
+  return this._request.apply(this, ['PUT'].concat(args));
 };
 
 Frisby.prototype.delete = function (/* [uri, data, params] */) {
   var args = Array.prototype.slice.call(arguments);
-  return this._request.apply(this, ['delete'].concat(args));
+  return this._request.apply(this, ['DELETE'].concat(args));
 };
 
 Frisby.prototype.head = function (/* [uri, params] */) {
   var args = Array.prototype.slice.call(arguments);
   args.splice(1, -1, null);
-  return this._request.apply(this, ['head'].concat(args));
+  return this._request.apply(this, ['HEAD'].concat(args));
 };
 
 Frisby.prototype._request = function (/* method [uri, data, params] */) {


### PR DESCRIPTION
Thanks for creating frisby!

I ran into a problem implementing HTTP Digest Authentication with frisbyjs that came down to the case of the HTTP methods.  The methods are case-sensitive and should be in all caps (http://www.w3.org/Protocols/HTTP/Methods.html).

This is important for HTTP digest auth because the method is used as a part of building the HA2 hash.
