### PR TITLE
Concat header before method

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -136,7 +136,7 @@ Frisby.prototype.not = function() {
 // @param string header value content
 //
 Frisby.prototype.addHeader = function(header, content) {
-  this.current.request.headers[header+"".toLowerCase()] = content+"".toLowerCase();
+  this.current.request.headers[(header+"").toLowerCase()] = (content+"").toLowerCase();
   return this;
 };
 
@@ -161,7 +161,7 @@ Frisby.prototype.setHeaders = function(headers) {
 // @param string header key
 //
 Frisby.prototype.removeHeader = function (key) {
-  delete this.current.request.headers[key+"".toLowerCase()];
+  delete this.current.request.headers[(key+"").toLowerCase()];
   return this;
 };
 
@@ -360,7 +360,7 @@ Frisby.prototype.expectStatus = function(statusCode) {
 // HTTP header expect helper
 Frisby.prototype.expectHeader = function(header, content) {
   var self = this;
-  var header = header+"".toLowerCase();
+  var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
     if(typeof self.current.response.headers[header] !== "undefined") {
       expect(self.current.response.headers[header].toLowerCase()).toEqual(content.toLowerCase());
@@ -374,7 +374,7 @@ Frisby.prototype.expectHeader = function(header, content) {
 // HTTP header expect helper (less strict version using 'contains' instead of strict 'equals')
 Frisby.prototype.expectHeaderContains = function(header, content) {
   var self = this;
-  var header = header+"".toLowerCase();
+  var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
     if(typeof self.current.response.headers[header] !== "undefined") {
       expect(self.current.response.headers[header].toLowerCase()).toContain(content.toLowerCase());


### PR DESCRIPTION
Testing using:
node v0.8.23
jasmine-node: 1.7.1

When testing something like:

``` javascript
.expectHeaderContains('Content-Type', 'json');
```

The assertion failed, but if I changed it to: 

``` javascript
.expectHeaderContains('content-type', 'json');
```

it worked.

It seems the `object+"".toLowerString()` execution order happening was toLowerString() would lower case the empty string then concatenate to the object. 
