### PR TITLE
Adding an inspectHeaders debug helper.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -697,6 +697,14 @@ Frisby.prototype.inspectResponse = function() {
   return this;
 };
 
+// Debugging helper to inspect the HTTP headers that are returned from the server
+Frisby.prototype.inspectHeaders = function(){
+  this.after(function(err, res, body) {
+    console.log(res.headers);
+  });
+  return this;
+};
+
 // Debugging helper to inspect HTTP response body content recieved from server
 Frisby.prototype.inspectBody = function() {
   this.after(function(err, res, body) {


### PR DESCRIPTION
Adding a debug helper to look at the response headers only instead of wading through the full response from a node call just to look at the headers that were returned.
