### PR TITLE
Gives params a higher precedence than this.current.request

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -251,7 +251,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       };
 
   // Merge 'current' request options for current request
-  _.extend(outgoing, params || {}, this.current.request);
+  _.extend(outgoing, this.current.request, params || {});
   //_.extend(outgoing.headers, this.current.request.headers);
 
   // Ensure we have at least one 'content-type' header


### PR DESCRIPTION
This change allows one to override headers in the .get call, whereas they are currently being trampled by the empty entry in this.current.request.  I need to be able to set cookies on my get call and currently I cannot. This is important
