### PR TITLE
Add support for JSONSchema files and objects

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -1,6 +1,6 @@
 //
 // Frisby.js
-// (c) 2011 Vance Lucas, Brightbit, LLC
+// (c) 2011-2014 Vance Lucas, Brightbit, LLC
 //
 // Frisby is a library designed to easily test REST API endpoints and their responses with node.js and Jasmine
 //
@@ -11,7 +11,11 @@ var qs = require('qs')
   ,  util = require('util')
   , request = require('request')
   , _ = require('underscore')
-  , bignumJSON = require('json-bignum');
+  , bignumJSON = require('json-bignum')
+  , JSONSchemaValidate = require('json-schema').validate
+  , stackTrace = require('stack-trace')
+  , fs = require('fs')
+  , path = require('path');
 
 
 //
@@ -592,6 +596,42 @@ Frisby.prototype.expectJSON = function(jsonTest) {
       expect(jsonBody).toContainJson(jsonTest, self.current.isNot);
     }
   });
+  return this;
+};
+
+
+// Helper to validate JSON response against provided JSONSchema structure or document
+Frisby.prototype.expectJSONSchema = function(jsonSchema) {
+  var self = this;
+
+  // String = file path
+  if(typeof jsonSchema === 'string') {
+    var jsonSchemaFile = jsonSchema;
+    // Allows relative file paths from Frisby specs
+    if(!fs.existsSync(jsonSchemaFile)) {
+      var trace       = stackTrace.parse(new Error());
+      var callingFile = trace[1].getFileName();
+      var callingDir  = path.dirname(callingFile)
+      jsonSchemaFile = path.join(callingDir, jsonSchema);
+    }
+    var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
+    jsonSchema      = JSON.parse(data);
+  }
+
+  this.current.expects.push(function() {
+    var jsonBody = _jsonParse(self.current.response.body);
+    var res = JSONSchemaValidate(jsonBody, jsonSchema);
+    if(res.valid === true) {
+      // Use assertion to keep assertion count accurate
+      expect(res.valid).toBeTruthy();
+    } else {
+      // JSONSchema failures - show each one to user
+      throw new Error("JSONSchema validation failed with the following errors: \n\t> " +
+        res.errors.map(function(err) { return err.message; }).join("\n\t> ")
+      );
+    }
+  });
+
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "request": "2.x.x",
     "json-bignum": "0.0.x",
+    "json-schema": "0.2.x",
+    "stack-trace": "0.0.x",
     "mock-request": ">= 0.1.2",
     "nock": "*",
     "underscore": "1.2.x",

--- a/spec/fixtures/json_schema/response1.json
+++ b/spec/fixtures/json_schema/response1.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Product",
+    "description": "A product from Acme's catalog",
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "The unique identifier for a product",
+            "type": "integer"
+        },
+        "name": {
+            "description": "Name of the product",
+            "type": "string"
+        },
+        "price": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "tags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "required": ["id", "name", "price"]
+}

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -1,0 +1,74 @@
+var nock = require('nock');
+var frisby = require('../lib/frisby');
+var path = require('path');
+
+// Nock to intercept HTTP requests for testing
+nock('http://example.com', { allowUnmocked: false })
+  .persist()
+  // @link http://json-schema.org/example1.html
+  .get('/response1')
+  .reply(200, {
+    "id": 1,
+    "name": "A green door",
+    "price": 12.50,
+    "tags": ["home", "green"]
+  });
+
+//
+// Tests
+//
+describe('Frisby JSONSchema', function() {
+
+  it('should accept and validate JSONSchema object', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response1', {foo: 'bar'})
+      .expectStatus(200)
+      .expectJSONSchema({
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Product",
+        "description": "A product from Acme's catalog",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier for a product",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Name of the product",
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+          }
+        },
+        "required": ["id", "name", "price"]
+      })
+    .toss();
+  });
+
+  it('should accept and validate JSONSchema file with relative path', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response1', {foo: 'bar'})
+      .expectStatus(200)
+      .expectJSONSchema('fixtures/json_schema/response1.json')
+    .toss();
+  });
+
+  it('should accept and validate JSONSchema file with full root path', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response1', {foo: 'bar'})
+      .expectStatus(200)
+      .expectJSONSchema(path.join(__dirname, 'fixtures/json_schema/response1.json'))
+    .toss();
+  });
+});


### PR DESCRIPTION
Adds new matcher called `expectJSONSchema` and adds tests to ensure JSON Schema support is working properly.

More on JSON Schema: http://json-schema.org/
