### PR TITLE
add possibility to globally switch contenttype to json for put/post

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -23,7 +23,8 @@ var qs = require('qs')
 //
 var _frisbyGlobalSetup = {
   request: {
-    headers: {}
+    headers: {},
+    json: false
   }
 };
 var globalSetup = function(opts) {
@@ -32,6 +33,7 @@ var globalSetup = function(opts) {
     if(typeof _frisbyGlobalSetup.request === "undefined") {
       _frisbyGlobalSetup.request = {};
       _frisbyGlobalSetup.request.headers = {};
+      _frisbyGlobalSetup.request.json = false;
     }
   }
   return _frisbyGlobalSetup;
@@ -325,7 +327,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       port    = this.port && this.port !== 80 ? ':' + this.port : '',
       fullUri,
       outgoing = {
-        json: params.json || false,
+        json: params.json || (_frisbyGlobalSetup && _frisbyGlobalSetup.request && _frisbyGlobalSetup.request.json || false),
         uri: null,
         body: params.body || null,
         method: 'GET',

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -6,7 +6,8 @@ describe('Frisby object setup', function() {
   it('global setup should be empty', function() {
     expect({
       request: {
-        headers: {}
+        headers: {},
+        json: false
       }
     }).toEqual(frisby.globalSetup());
   });
@@ -15,7 +16,8 @@ describe('Frisby object setup', function() {
     var f1 = frisby.create('test 1');
 
     expect({
-      headers: {}
+      headers: {},
+      json: false
     }).toEqual(f1.current.request);
   });
 
@@ -40,5 +42,42 @@ describe('Frisby object setup', function() {
     // Different setup
     expect(f1.current.request).not.toEqual(f2.current.request);
   });
+
+    it('should default to json = false', function() {
+        expect({
+            request: {
+                headers: {},
+                json: false
+            }
+        }).toEqual(frisby.globalSetup());
+
+        expect(frisby.create('mytest').get('/path').current.outgoing.json).toEqual(false);
+    });
+
+
+    it('should switch to json default = true when global config is configured json', function() {
+        frisby.globalSetup().request.json = true;
+        expect({
+            request: {
+                headers: {},
+                json: true
+            }
+        }).toEqual(frisby.globalSetup());
+
+        expect(frisby.create('mytest').get('/path').current.outgoing.json).toEqual(true);
+    });
+
+    it('should be overridable by the params parameter json=false', function() {
+        frisby.globalSetup().request.json = true;
+        expect({
+            request: {
+                headers: {},
+                json: true
+            }
+        }).toEqual(frisby.globalSetup());
+
+        expect(frisby.create('mytest').get('/path', {json:false}).current.outgoing.json).toEqual(false);
+    });
+
 
 });


### PR DESCRIPTION
I added a property to the globalSetup to specify that I globally want to use {json:true} for all my tests
