### PR TITLE
Allow false value for the data argument for raw body request.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -322,7 +322,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       args    = Array.prototype.slice.call(arguments),
       method  = args.shift(),
       uri     = typeof args[0] === 'string' && args.shift(),
-      data    = (args[0] === false || typeof args[0] === 'object') && args.shift(),
+      data    = typeof args[0] === 'object' && args.shift(),
       params  = typeof args[0] === 'object' && args.shift(),
       port    = this.port && this.port !== 80 ? ':' + this.port : '',
       fullUri,
@@ -352,7 +352,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   // If the user has provided data, assume that it is query string
   // and set it to the `body` property of the options.
   //
-  if (data) {
+  if (!_.isEmpty(data)) {
     // if JSON data
     if(outgoing.json) {
       outgoing.headers['content-type'] = 'application/json';

--- a/spec/frisby_mock_request_spec.js
+++ b/spec/frisby_mock_request_spec.js
@@ -655,7 +655,7 @@ describe('Frisby matchers', function() {
   it('should allow for passing raw request body', function() {
     // Intercepted with 'nock'
     frisby.create(this.description)
-      .post('http://httpbin.org/raw', false, {
+      .post('http://httpbin.org/raw', {}, {
         body: 'some body here',
       })
       .expectStatus(200)


### PR DESCRIPTION
Right now, it seems impossible to simply send raw content as part of the request body (for example if I was expecting to send XML). The issue is the need to set `data` to an empty object to get access to setting the `params` argument (`params.body`). However, when setting `data` to an empty object, the `if (data)` gets a truthy value from the empty object and overwrites the `outgoing.body`.

There were two options to fixing this issue.
- Add an additional parameter to the `params` argument to specify the `params.body` as being paramount:

``` javascript
frisby.create('...')
  .post('someurl.com', {}, {body: 'some body', raw: true})
.toss();
```
- Allow for `false` in the `data` argument to bypass the `outgoing.body` override:

``` javascript
frisby.create('...')
  .post('someurl.com', false, {body: 'some body'})
.toss();
```

I opted for the later option here, but fine with either (or a different approach altogether). Either of these approaches seemed to be the easiest to ensure backwards compatibility.
