### PR TITLE
added support for sending binary data with put and post via Buffer objec...

### DIFF
--- a/examples/httpbin_binary_post_put_spec.js
+++ b/examples/httpbin_binary_post_put_spec.js
@@ -1,0 +1,72 @@
+/**
+ * frisby.js: Binary Data PUT/POST Example (to httpbin.org)
+ *
+ * In order to send binary data using a POST request you need to:
+ *  - pass the binary data as a Buffer (second param to post)
+ *  - set the json option to false (third param)
+ *  - add a "content-type" header with value "application/octet-stream" to the options (third param)
+ *
+ * httpbin.org/post replies with the data encoded in a base64 string
+ *
+ * author: Stefan Kreutter
+ */
+var frisby = require('../lib/frisby');
+var fs = require('fs');
+var path = require('path');
+
+var logo = fs.readFileSync(path.resolve(__dirname, '../spec/logo-frisby.png'));
+
+frisby.create('POST frisby logo to http://httpbin.org/post')
+    .post('http://httpbin.org/post',
+        logo,
+        {
+            json: false,
+            headers: {
+                "content-type": "application/octet-stream"
+            }
+        })
+        .expectStatus(200)
+        .expectHeaderContains('content-type', 'application/json')
+        .expectJSON({
+            data: 'data:application/octet-stream;base64,' + logo.toString('base64'),
+            headers: {
+                "Content-Type": "application/octet-stream",
+                "Content-Length": "4168"
+            },
+            url: "http://httpbin.org/post",
+            json: null,
+            files: {},
+            form: {}
+        })
+        .expectJSONTypes({
+            data: String
+        })
+        .toss();
+
+frisby.create('PUT frisby logo to http://httpbin.org/post')
+    .put('http://httpbin.org/put',
+        logo,
+        {
+            json: false,
+            headers: {
+                "content-type": "application/octet-stream"
+            }
+        })
+        .expectStatus(200)
+        .expectHeaderContains('content-type', 'application/json')
+        .expectJSON({
+            data: 'data:application/octet-stream;base64,' + logo.toString('base64'),
+            headers: {
+                "Content-Type": "application/octet-stream",
+                "Content-Length": "4168"
+            },
+            url: "http://httpbin.org/put",
+            json: null,
+            files: {},
+            form: {}
+        })
+        .expectJSONTypes({
+            data: String
+        })
+        .toss();
+

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -360,7 +360,11 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       outgoing.headers['content-type'] = 'application/json';
       outgoing.body = bignumJSON.stringify(data);
     } else if(!outgoing.body) {
-      outgoing.body = qs.stringify(data);
+      if(data instanceof Buffer) {
+        outgoing.body = data;
+      } else {
+        outgoing.body = qs.stringify(data);
+      }
     }
   }
 

--- a/spec/frisby_httpbin_spec.js
+++ b/spec/frisby_httpbin_spec.js
@@ -26,4 +26,68 @@ describe('Frisby live running httpbin tests', function() {
 
   });
 
+  it('sending binary data via put or post requests should work', function() {
+
+      var data = [];
+
+      for(var i=0; i< 1024; i++)
+        data.push(Math.round(Math.random()*256))
+
+
+      frisby.create('POST random binary data')
+        .post('http://httpbin.org/post',
+              new Buffer(data),
+              {
+                  json : false,
+                  headers : {
+                      "content-type" : "application/octet-stream"
+                  }
+              })
+          .expectStatus(200)
+          .expectHeaderContains('content-type', 'application/json')
+          .expectJSON({
+                  data : 'data:application/octet-stream;base64,'+ new Buffer(data).toString('base64'),
+                  headers: {
+                      "Content-Type": "application/octet-stream",
+                      "Content-Length" : "1024"
+                  },
+                  url: "http://httpbin.org/post",
+                  json : null,
+                  files: {},
+                  form: {}
+              })
+          .expectJSONTypes({
+                  data: String
+              })
+      .toss();
+
+      frisby.create('PUT random binary data')
+        .put('http://httpbin.org/put',
+              new Buffer(data),
+              {
+                  json : false,
+                  headers : {
+                      "content-type" : "application/octet-stream"
+                  }
+              })
+          .expectStatus(200)
+          .expectHeaderContains('content-type', 'application/json')
+          .expectJSON({
+                  data : 'data:application/octet-stream;base64,'+ new Buffer(data).toString('base64'),
+                  headers: {
+                      "Content-Type": "application/octet-stream",
+                      "Content-Length" : "1024"
+                  },
+                  url: "http://httpbin.org/put",
+                  json : null,
+                  files: {},
+                  form: {}
+              })
+          .expectJSONTypes({
+                  data: String
+              })
+      .toss();
+
+  });
+
 });


### PR DESCRIPTION
As far as I understand frisby is not able to post or put binary data. I made a small change to frisby.js to accept a Buffer object as data (without converting it to a string). Tests and an example are provided as well.
