### PR TITLE
Use request package, add digestAuth handling

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -276,12 +276,14 @@ Frisby.prototype.responseType = function(type) {
 //
 // @param string username
 // @param string password
+// @param boolean digest
 //
-Frisby.prototype.auth = function(user, pass) {
+Frisby.prototype.auth = function(user, pass, digest) {
   this.current.outgoing.auth = {
+    sendImmediately: !digest,
     user: user,
     pass: pass
-  }
+  };
   return this;
 };
 

--- a/spec/frisby_httpbin_spec.js
+++ b/spec/frisby_httpbin_spec.js
@@ -17,6 +17,35 @@ describe('Frisby live running httpbin tests', function() {
 
   });
 
+  describe('Frisby digestAuth', function() {
+
+    it('should not work if digest not set', function() {
+
+      frisby.create('test with httpbin for invalid digest auth')
+        .auth('frisby', 'passwd')
+        .get('http://httpbin.org/digest-auth/auth/frisby/passwd')
+        .expectStatus(401)
+      .toss();
+
+    });
+
+
+    /*
+    // Digest auth against httpbin not working for some reason
+    // but working fine against my own servers running digest auth
+    it('should work if digest set', function() {
+
+      frisby.create('test with httpbin for valid digest auth')
+        .auth('frisby', 'passwd', true)
+        .get('http://httpbin.org/digest-auth/auth/frisby/passwd')
+        .expectStatus(200)
+      .toss();
+
+    });
+    */
+
+  });
+
   it('should pass in param hash to request call dependency', function() {
 
     frisby.create('test with httpbin for valid basic auth')

--- a/spec/frisby_mock_request_spec.js
+++ b/spec/frisby_mock_request_spec.js
@@ -619,7 +619,7 @@ describe('Frisby matchers', function() {
       .expectHeader('Authorization', 'Basic ZnJpc2J5OnBhc3N3ZA==')
       .after(function(err, res, body) {
         // Check to ensure outgoing set for basic auth
-        expect(this.current.outgoing.auth).toEqual({ user: 'frisby', pass: 'passwd' });
+        expect(this.current.outgoing.auth).toEqual({ user: 'frisby', pass: 'passwd', sendImmediately: true });
 
         // Check to ensure response headers contain basic auth header
         expect(this.current.response.headers.authorization).toBe('Basic ZnJpc2J5OnBhc3N3ZA==');


### PR DESCRIPTION
Two commits here.  

The first just switches to using request instead of building your own hash.  That's all good.  Tests updated and passing.

The second updates `auth` to add a `digest` flag.  

Good news, bad news.  For whatever reason I can't get digestAuth to work vs httpbin.  It works fine against my own servers running digestAuth.  I've included a test vs httpbin but commented it out as it fails.  I understand if you rather not merge the 2nd commit.  Unfortunately I'm at a point where I have it working and need to get moving with it.  I'm happy working with my branch if need be.
