### PR TITLE
add expectBodyCustom to run custom body verification

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -519,6 +519,22 @@ Frisby.prototype.expectBodyContains = function(content) {
   return this;
 };
 
+// HTTP custom body expect helper
+//
+// @param customMatcher function that verify the body
+//
+Frisby.prototype.expectBodyCustom = function(customMatcher) {
+  var self = this;
+  this.current.expects.push(function() {
+    if(!_.isUndefined(self.current.response.body)) {
+      customMatcher(self.current.response.body);
+    } else {
+      throw new Error("No HTTP response body was present or HTTP response was empty");
+    }
+  });
+  return this;
+};
+
 // Helper to check parse HTTP response body as JSON and check key types
 Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
   var self     = this,


### PR DESCRIPTION
I've the use case when I want to test images returned by getting some url. It's probably too specific to add as an expect to the whole Frisby, but having option to define custom body match functions would allow to address such scenario.
