### PR TITLE
Remove strict SSL checking

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -337,7 +337,8 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
         method: 'GET',
         headers: {
           'content-type': 'application/x-www-form-urlencoded'
-        }
+        },
+		strictSSL: false
       };
 
   // Explicit setting of 'body' param overrides data


### PR DESCRIPTION
Removed strict SSL certificate checking by adding the 
    strictSSL: false
parameter to the request.js http request. The developer testing the API will not be checking the validity of the server's certificate, and if the server in question is a local dev. server, the https ssl certificate may not be valid.
