### PR TITLE
Add methods to get response headers.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -864,50 +864,79 @@ Frisby.prototype.expectJSONLength = function(expectedLength) {
 
 
 // Debugging helper to inspect HTTP request sent by Frisby
-Frisby.prototype.inspectRequest = function() {
+Frisby.prototype.inspectRequest = function(message) {
   var self = this;
   this.after(function(err, res, body) {
-    console.log(self.currentRequestFinished.req);
+    if (message) {
+        console.log(message)
+        console.log(self.currentRequestFinished.req);
+    } else {
+        console.log(self.currentRequestFinished.req);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response received from server
-Frisby.prototype.inspectResponse = function() {
+Frisby.prototype.inspectResponse = function(message) {
   this.after(function(err, res, body) {
-    console.log(res);
+    if (message) {
+        console.log(message)
+        console.log(res);
+    } else {
+        console.log(res);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect the HTTP headers that are returned from the server
-Frisby.prototype.inspectHeaders = function(){
+Frisby.prototype.inspectHeaders = function(message){
   this.after(function(err, res, body) {
-    console.log(res.headers);
+    if (message) {
+        console.log(message)
+        console.log(res.headers);
+    } else {
+        console.log(res.headers);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response body content received from server
-Frisby.prototype.inspectBody = function() {
+Frisby.prototype.inspectBody = function(message) {
   this.after(function(err, res, body) {
-    console.log(body);
+    if (message) {
+        console.log(message)
+        console.log(body);
+    } else {
+        console.log(body);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect JSON response body content received from server
-Frisby.prototype.inspectJSON = function() {
+Frisby.prototype.inspectJSON = function(message) {
   this.after(function(err, res, body) {
-    console.log(util.inspect(_jsonParse(body), false, 10, true));
+    if (message) {
+        console.log(message + '\n' + util.inspect(_jsonParse(body), false, 10, true));
+    } else {
+        console.log(util.inspect(_jsonParse(body), false, 10, true));
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response code received from server
-Frisby.prototype.inspectStatus = function() {
+Frisby.prototype.inspectStatus = function(message) {
   this.after(function(err, res, body) {
-    console.log(res.statusCode);
+    if (message) {
+        console.log(message)
+        console.log(res.statusCode);
+    } else {
+        console.log(res.statusCode);
+    }
   });
   return this;
 };


### PR DESCRIPTION
I've added the following methods that provide access to the response headers as part of the callback function.
- afterResponseHeaders
- afterJSONWithResponseHeaders
