### PR TITLE
Jasmine 2.0 port

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -1004,7 +1004,7 @@ Frisby.prototype.toss = function(retry) {
 
     // Add custom matchers to spec
     beforeEach(function(){
-      jasmine.addMatchers(customMatchers);
+      jasmine.addMatchers(exports.matchers);
     });
 
     // Spec test (async: beware of jasmine's default 5sec timeout for async spec's)
@@ -1135,109 +1135,6 @@ Frisby.prototype.toss = function(retry) {
 
 
 //
-// Add custom Frisby matchers to Jasmine (globally)
-// // Updated to jasmine2.0 syntax // //
-//
-var customMatchers = {
-  toMatchOrBeNull: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        return {
-          pass: (new RegExp(expected).test(this.actual)) || (this.actual === null)
-        }
-      }
-    }
-  },
-  toMatchOrBeEmpty: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        return {
-          pass: (new RegExp(expected).test(this.actual)) || (this.actual === null) || (this.actual === "")
-        }
-      }
-    }
-  },
-  toBeType: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        var aType = _toType(actual);
-        var eType = _toType(expected);
-        // Function is not a valid JSON type
-        if("function" === eType) {
-          eType = _toType(expected.prototype);
-        }
-        return {
-          pass: aType === eType
-        }
-      }
-    }
-  },
-  toBeTypeOrNull: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        var aType = _toType(actual);
-        var eType = _toType(expected);
-        // Function is not a valid JSON type
-        if("function" === eType) {
-          eType = _toType(expected.prototype);
-        }
-        return {
-          pass: (this.actual === null) || (_toType(this.actual) === eType)
-        }
-      }
-    }
-  },
-  toBeTypeOrUndefined: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        var aType = _toType(actual);
-        var eType = _toType(expected);
-        // Function is not a valid JSON type
-        if("function" === eType) {
-          eType = _toType(expected.prototype);
-        }
-        return {
-          pass: (this.actual === undefined) || (_toType(this.actual) === eType)
-        }
-      }
-    }
-  },
-  toContainJson: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        // Way of allowing custom failure message - by throwing exceptions in utility function
-        try {
-          return {
-            pass: _jsonContains(actual, expected)
-          };
-        } catch(e) {
-          return {
-            pass: false
-          };
-        }
-      }
-    }
-  },
-  toContainJsonTypes: function(util, customEqualityTester) {
-    return {
-      compare: function(actual, expected) {
-        // Way of allowing custom failure message - by throwing exceptions in utility function
-        try {
-          return {
-            pass: _jsonContainsTypes(actual, expected)
-          };
-        } catch(e) {
-          // Fail test if there is a match failure and it is not an inverse test (for non-match)
-          return {
-            pass: false
-          };
-        }
-      }
-    }
-  }
-}
-
-//
 // Parse body as JSON, ensuring not to re-parse when body is already an object (thanks @dcaylor)
 //
 function _jsonParse(body) {
@@ -1365,6 +1262,114 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
   }
 
   return true;
+}
+
+
+////////////////////
+// Module Exports //
+////////////////////
+
+
+//
+// Export Frisby Matchers (to be used in unit tests; to be applied in toss()'s beforeEach')
+//
+exports.matchers = {
+  toMatchOrBeNull: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        return {
+          pass: (new RegExp(expected).test(actual)) || (actual === null)
+        }
+      }
+    }
+  },
+  toMatchOrBeEmpty: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        return {
+          pass: (new RegExp(expected).test(actual)) || (actual === null) || (actual === "")
+        }
+      }
+    }
+  },
+  toBeType: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        var aType = _toType(actual);
+        var eType = _toType(expected);
+        // Function is not a valid JSON type
+        if("function" === eType) {
+          eType = _toType(expected.prototype);
+        }
+        return {
+          pass: aType === eType
+        }
+      }
+    }
+  },
+  toBeTypeOrNull: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        var aType = _toType(actual);
+        var eType = _toType(expected);
+        // Function is not a valid JSON type
+        if("function" === eType) {
+          eType = _toType(expected.prototype);
+        }
+        return {
+          pass: (actual === null) || (_toType(actual) === eType)
+        }
+      }
+    }
+  },
+  toBeTypeOrUndefined: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        var aType = _toType(actual);
+        var eType = _toType(expected);
+        // Function is not a valid JSON type
+        if("function" === eType) {
+          eType = _toType(expected.prototype);
+        }
+        return {
+          pass: (actual === undefined) || (_toType(actual) === eType)
+        }
+      }
+    }
+  },
+  toContainJson: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        // Way of allowing custom failure message - by throwing exceptions in utility function
+        try {
+          return {
+            pass: _jsonContains(actual, expected)
+          };
+        } catch(e) {
+          return {
+            pass: false
+          };
+        }
+      }
+    }
+  },
+  toContainJsonTypes: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        // Way of allowing custom failure message - by throwing exceptions in utility function
+        try {
+          return {
+            pass: _jsonContainsTypes(actual, expected)
+          };
+        } catch(e) {
+          // Fail test if there is a match failure and it is not an inverse test (for non-match)
+          return {
+            pass: false
+          };
+        }
+      }
+    }
+  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "qs": "1.2.x"
   },
   "devDependencies": {
-    "jasmine-node": "~1.14.5",
-    "form-data": "~0.1.4"
+    "form-data": "~0.1.4",
+    "minijasminenode2": "^1.0.0"
   },
   "main": "./lib/frisby",
   "engines": {
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "jasmine-node spec/"
+    "test": "minijasminenode2 spec/*.js"
   }
 }

--- a/spec/frisby_matchers_spec.js
+++ b/spec/frisby_matchers_spec.js
@@ -1,8 +1,11 @@
 var frisby = require('../lib/frisby');
-var mockRequest = require('mock-request')
-
+var mockRequest = require('mock-request');
 
 describe('Frisby matchers', function() {
+
+  beforeEach(function(){
+    jasmine.addMatchers(frisby.matchers);
+  });
 
   it('toContainJSON should match exactly', function() {
     // Set fake JSON body

--- a/spec/frisby_withpath_spec.js
+++ b/spec/frisby_withpath_spec.js
@@ -2,6 +2,11 @@ var frisby = require('../lib/frisby');
 
 describe('Frisby withPath syntax', function() {
 
+  // Manually add Frisby matchers (otherwise done in toss())
+  beforeEach(function(){
+    jasmine.addMatchers(frisby.matchers);
+  });
+
   it('should work with single string path', function() {
     frisby.withPath('response', {
         response: {


### PR DESCRIPTION
Fixing Breaking Changes for Jasmine 2.0 (http://jasmine.github.io/2.0/upgrading.html)
- Ported custom matchers
  - new definition syntax
  - used in `beforeEach`
  - exported on module, to be used in test suite
- Ported async code to new syntax
  - `runs`/`waits`/`waitsFor` have been replaced by `done`

Have a closer look at the `toss` function if anything important  was lost in the rewrite. Works as expected though.
