### PR TITLE
fixed range for request module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "frisby"
   ],
   "dependencies": {
-    "request": "2.x.x",
+    "request": ">=2.0.0 <2.50",
     "jsonschema": "1.0.0",
     "stack-trace": "0.0.x",
     "mock-request": ">= 0.1.2",


### PR DESCRIPTION
request 2.49 and 2.50 are incompatible which changes outcome of frisby 0.8.x tests. Until this PR is merged (or the underlying issue is fixed in another way) users can overcome trouble by adding `request` in a version <2.50 to their dependencies:

```
    "devDependencies": {
        "frisby": "~0.8",
        "request": "~2.49",
        ...
     }
```
