### PR TITLE
Added inspectOnFailureRequest option sometimes is needed to log the requ...

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -25,6 +25,7 @@ var _frisbyGlobalSetup = {
   request: {
     headers: {},
     inspectOnFailure: false,
+    inspectOnFailureRequest: false,
     json: false
   }
 };
@@ -35,6 +36,7 @@ var globalSetup = function(opts) {
       _frisbyGlobalSetup.request = {};
       _frisbyGlobalSetup.request.headers = {};
       _frisbyGlobalSetup.request.inspectOnFailure = false;
+      _frisbyGlobalSetup.request.inspectOnFailureRequest = false;
       _frisbyGlobalSetup.request.json = false;
     }
   }
@@ -1088,8 +1090,13 @@ Frisby.prototype.toss = function(retry) {
             console.log(self.current.itInfo + ' has FAILED with the following response:');
             self.inspectStatus();
             self.inspectJSON();
-          };
+            if(self.current.outgoing.inspectOnFailureRequest) {
+              self.inspectRequest();
+              self.inspectHeaders();
+            }
 
+          };
+          
           // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
           // this enables after to add more after to do things (like inspectJSON)
           for(i=0; i < self.current.after.length; i++) {

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -26,7 +26,8 @@ var _frisbyGlobalSetup = {
     headers: {},
     inspectOnFailure: false,
     inspectOnFailureRequest: false,
-    json: false
+    json: false,
+    baseUri: ''
   }
 };
 var globalSetup = function(opts) {
@@ -38,6 +39,7 @@ var globalSetup = function(opts) {
       _frisbyGlobalSetup.request.inspectOnFailure = false;
       _frisbyGlobalSetup.request.inspectOnFailureRequest = false;
       _frisbyGlobalSetup.request.json = false;
+      _frisbyGlobalSetup.request.baseUri = '';
     }
   }
   return _frisbyGlobalSetup;
@@ -323,6 +325,12 @@ Frisby.prototype.head = function (/* [uri, params] */) {
   return this._request.apply(this, ['HEAD'].concat(args));
 };
 
+Frisby.prototype.options = function (/* [uri, params] */) {
+    var args = Array.prototype.slice.call(arguments);
+    args.splice(1, -1, null);
+    return this._request.apply(this, ['OPTIONS'].concat(args));
+};
+
 var _hasHeader = function (headername, headers) {
   var headerNames = Object.keys(headers || {});
   var lowerNames = headerNames.map(function (name) {return name.toLowerCase()});
@@ -372,7 +380,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   }
 
   // Set outgoing URI
-  outgoing.uri = uri;
+  outgoing.uri = (_frisbyGlobalSetup && _frisbyGlobalSetup.request && _frisbyGlobalSetup.request.baseUri || '') + uri;
 
   //
   // If the user has provided data, assume that it is query string
@@ -382,7 +390,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
     // if JSON data
     if(outgoing.json) {
       outgoing.headers['content-type'] = 'application/json';
-      outgoing.body = JSON.stringify(data);
+      outgoing.body = data;
     } else if(!outgoing.body) {
       if(data instanceof Buffer) {
         outgoing.body = data;
@@ -417,14 +425,14 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   // Add the topic for the specified request to the context of the current
   // batch used by this suite.
   //
-  this.current.it = function () {
+  this.current.it = function (cb) {
     self.currentRequestFinished = false;
     var start = (new Date).getTime();
     var runCallback = function(err, res, body) {
 
       // Timeout is now handled by request
       if(err) {
-        body = "Destination URL may be down or URL is invalid.";
+        body = "Destination URL may be down or URL is invalid, " + err;
       }
 
       var diff = (new Date).getTime() - start;
@@ -444,6 +452,11 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
         body: body,
         time: diff
       };
+
+      // call caller's callback
+      if (cb && typeof cb === "function") {
+        cb(self.current.response);
+      }
     };
 
     outgoing['timeout'] = self._timeout;
@@ -866,50 +879,79 @@ Frisby.prototype.expectJSONLength = function(expectedLength) {
 
 
 // Debugging helper to inspect HTTP request sent by Frisby
-Frisby.prototype.inspectRequest = function() {
+Frisby.prototype.inspectRequest = function(message) {
   var self = this;
   this.after(function(err, res, body) {
-    console.log(self.currentRequestFinished.req);
+    if (message) {
+        console.log(message)
+        console.log(self.currentRequestFinished.req);
+    } else {
+        console.log(self.currentRequestFinished.req);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response received from server
-Frisby.prototype.inspectResponse = function() {
+Frisby.prototype.inspectResponse = function(message) {
   this.after(function(err, res, body) {
-    console.log(res);
+    if (message) {
+        console.log(message)
+        console.log(res);
+    } else {
+        console.log(res);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect the HTTP headers that are returned from the server
-Frisby.prototype.inspectHeaders = function(){
+Frisby.prototype.inspectHeaders = function(message){
   this.after(function(err, res, body) {
-    console.log(res.headers);
+    if (message) {
+        console.log(message)
+        console.log(res.headers);
+    } else {
+        console.log(res.headers);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response body content received from server
-Frisby.prototype.inspectBody = function() {
+Frisby.prototype.inspectBody = function(message) {
   this.after(function(err, res, body) {
-    console.log(body);
+    if (message) {
+        console.log(message)
+        console.log(body);
+    } else {
+        console.log(body);
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect JSON response body content received from server
-Frisby.prototype.inspectJSON = function() {
+Frisby.prototype.inspectJSON = function(message) {
   this.after(function(err, res, body) {
-    console.log(util.inspect(_jsonParse(body), false, 10, true));
+    if (message) {
+        console.log(message + '\n' + util.inspect(_jsonParse(body), false, 10, true));
+    } else {
+        console.log(util.inspect(_jsonParse(body), false, 10, true));
+    }
   });
   return this;
 };
 
 // Debugging helper to inspect HTTP response code received from server
-Frisby.prototype.inspectStatus = function() {
+Frisby.prototype.inspectStatus = function(message) {
   this.after(function(err, res, body) {
-    console.log(res.statusCode);
+    if (message) {
+        console.log(message)
+        console.log(res.statusCode);
+    } else {
+        console.log(res.statusCode);
+    }
   });
   return this;
 };
@@ -931,7 +973,7 @@ Frisby.prototype.waits = function(millis) {
 Frisby.prototype.after = function(cb) {
   var self = this;
   this.current.after.push(function() {
-    cb.call(this, self.current.response.error, self.currentRequestFinished.res, self.current.response.body);
+    cb.call(this, self.current.response.error, self.currentRequestFinished.res, self.current.response.body, self.current.response.headers);
   });
   return this;
 };
@@ -941,8 +983,9 @@ Frisby.prototype.after = function(cb) {
 Frisby.prototype.afterJSON = function(cb) {
   var self = this;
   this.current.after.push(function() {
+    var responseHeaders = _jsonParse(self.current.response.headers);
     var bodyJSON = _jsonParse(self.current.response.body);
-    cb.call(this, bodyJSON);
+    cb.call(this, bodyJSON, responseHeaders);
   });
   return this;
 };
@@ -999,91 +1042,104 @@ Frisby.prototype.toss = function(retry) {
   // Assemble all Jasmine tests and RUN them!
   describe('Frisby Test: ' + self.current.describe, function() {
 
-    // Spec test
-    it("\n\t[ " + self.current.itInfo + " ]", function() {
+    // Add custom matchers to spec
+    beforeEach(function(){
+      jasmine.addMatchers(exports.matchers);
+    });
+
+    // Spec test (async: beware of jasmine's default 5sec timeout for async spec's)
+    it("\n\t[ " + self.current.itInfo + " ]", function(done) {
       // Ensure "it" scope is accessible to tests
       var it = this;
 
-      if (self.current.waits > 0) {
-        waits(self.current.waits);
-      }
+      // results_ seems to no long exsist on jasmine2.0, mock it
+      it.results_ = {
+        failedCount: 0
+      };
 
-      // Don't retry POST
+      // launch request
+      // repeat request for self.current.retry times if request does not respond with self._timeout ms (except for POST requests)
+      var tries = 0;
       var retries = (self.current.outgoing.method.toUpperCase() == "POST") ? 0 : self.current.retry;
 
-      // we need to loop for the first run + how many times we want to retry
-      // they will abort if the test succeeds
-      for (var x = 0; x < retries + 1; x++) {
-        runs(function() {
-          if (typeof this.n === "undefined") {
-            this.n = 0;
-          }
-          else {
-            this.n += 1;
-          }
-          if (this.abort) {
-            return;
-          }
+      // wait optinally, launch request
+      if (self.current.waits > 0) {
+        setTimeout(makeRequest, self.current.waits);
+      } else {
+        makeRequest();
+      }
 
-          if (this.n > 0) {
+
+      function makeRequest(){
+        var requestFinished = false;
+        var timeoutFinished = false;
+        tries++;
+
+        var timeoutId = setTimeout(function maxWait(){
+          timeoutFinished = true;
+          if (tries < retries+1){
+
             it.results_.totalCount = it.results_.passedCount = it.results_.failedCount = 0;
             it.results_.skipped = false;
             it.results_.items_ = [];
 
-            process.stdout.write('R');
-
-            waits(self.current.retry_backoff);
+            process.stdout.write('R')
+            makeRequest();
+          } else {
+            // should abort instead (it.spec.fail ?)
+            it.results_.failedCount = 1;
+            after();
+            // assert();
           }
+        }, self._timeout);
 
-          // Run "it" spec
-          self.current.it();
-
-          waitsFor(function(){
-            return self.currentRequestFinished;
-          }, "HTTP Request timed out before completing", self._timeout);
-
-          // Run Asserts
-          runs(function() {
-            if (self.currentRequestFinished) {
-              var i;
-              self.current.expectsFailed = true;
-
-              // if you have no expects, they can't fail
-              if (self.current.expects.length == 0) {
-                retry = -1;
-                this.abort = true;
-                self.current.expectsFailed = false;
-              }
-
-              // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
-              // Some 'expects' helpers add more tests when executed (recursive 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
-              for(i=0; i < self.current.expects.length; i++) {
-                if(false !== self._exceptionHandler) {
-                  try {
-                    self.current.expects[i].call(it);
-                  } catch(e) {
-                    self._exceptionHandler.call(self, e);
-                  }
-                } else {
-                  self.current.expects[i].call(it);
-                }
-              }
-
-              if (it.results_.failedCount == 0) {
-                retry = -1;
-                this.abort = true;
-                self.current.expectsFailed = false;
-              }
-            }
-            else {
-              it.results_.failedCount = 1;
-            }
-          });
+        self.current.it(function(data) {
+          if (!timeoutFinished) {
+            clearTimeout(timeoutId);
+            assert();
+          }
         });
       }
 
-      runs(function() {
-        // AFTER callback
+
+      // Assert callback
+      // called from makeRequest if request has finished successfully
+      function assert() {
+        var i;
+        self.current.expectsFailed = true;
+
+        // if you have no expects, they can't fail
+        if (self.current.expects.length == 0) {
+          retry = -1;
+          self.current.expectsFailed = false;
+        }
+
+        // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
+        // Some 'expects' helpers add more tests when executed (recursive 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
+        for(i=0; i < self.current.expects.length; i++) {
+          if(false !== self._exceptionHandler) {
+            try {
+              self.current.expects[i].call(it);
+            } catch(e) {
+              self._exceptionHandler.call(self, e);
+            }
+          } else {
+            self.current.expects[i].call(it);
+          }
+        }
+
+        if (it.results_.failedCount == 0) {
+          retry = -1;
+          self.current.expectsFailed = false;
+        }
+
+        // call after()
+        after();
+      }
+
+      // AFTER callback (execute further expects for the current spec)
+      // called from assert()
+      function after() {
         if(self.current.after) {
 
           if (self.current.expectsFailed && self.current.outgoing.inspectOnFailure) {
@@ -1112,98 +1168,14 @@ Frisby.prototype.toss = function(retry) {
             }
           }
         }
-      })
+
+        // finally call done to finish spec
+        done();
+      }
+
     });
+
   });
-};
-
-
-//
-// Add custom Frisby matchers to Jasmine (globally)
-//
-jasmine.Matchers.prototype.toMatchOrBeNull = function(expected) {
-  this.message = function() {
-    return "Expected '" + this.actual + "' to match '" + expected + "' or be null";
-  }
-  return (new RegExp(expected).test(this.actual)) || (this.actual === null);
-};
-jasmine.Matchers.prototype.toMatchOrBeEmpty = function(expected) {
-  this.message = function() {
-    return "Expected '" + this.actual + "' to match '" + expected + "' or be empty";
-  }
-  return (new RegExp(expected).test(this.actual)) || (this.actual === null) || (this.actual === "");
-};
-jasmine.Matchers.prototype.toBeType = function(expected) {
-  var aType = _toType(this.actual);
-  var eType = _toType(expected);
-  // Function is not a valid JSON type
-  if("function" === eType) {
-    eType = _toType(expected.prototype);
-  }
-  // Custom failure message
-  this.message = function() {
-    return "Expected '" + aType + "' to be type '" + eType + "'";
-  }
-  // Test
-  return aType === eType;
-};
-jasmine.Matchers.prototype.toBeTypeOrNull = function(expected) {
-  var aType = _toType(this.actual);
-  var eType = _toType(expected);
-  // Function is not a valid JSON type
-  if("function" === eType) {
-    eType = _toType(expected.prototype);
-  }
-  // Custom failure message
-  this.message = function() {
-    return "Expected '" + aType + "' to be type '" + eType + "' or null";
-  }
-  // Test
-  return (this.actual === null) || (_toType(this.actual) === eType);
-};
-jasmine.Matchers.prototype.toBeTypeOrUndefined = function(expected) {
-  var aType = _toType(this.actual);
-  var eType = _toType(expected);
-  // Function is not a valid JSON type
-  if("function" === eType) {
-    eType = _toType(expected.prototype);
-  }
-  // Custom failure message
-  this.message = function() {
-    return "Expected '" + aType + "' to be type '" + eType + "' or null";
-  }
-  // Test
-  return (this.actual === undefined) || (_toType(this.actual) === eType);
-};
-jasmine.Matchers.prototype.toContainJson = function(expected, isNot) {
-  this.message = function() {
-    return "Actual JSON did not match expected";
-  }
-
-  // Way of allowing custom failure message - by throwing exceptions in utility function
-  try {
-    return _jsonContains(this.actual, expected);
-  } catch(e) {
-    // Fail test if there is a match failure and it is not an inverse test (for non-match)
-    if(!this.isNot && !isNot) {
-      this.spec.fail(e);
-    }
-  }
-};
-jasmine.Matchers.prototype.toContainJsonTypes = function(expected, isNot) {
-  this.message = function() {
-    return "Actual JSON types did not match expected";
-  }
-
-  // Way of allowing custom failure message - by throwing exceptions in utility function
-  try {
-    return _jsonContainsTypes(this.actual, expected);
-  } catch(e) {
-    // Fail test if there is a match failure and it is not an inverse test (for non-match)
-    if(!this.isNot && !isNot) {
-      this.spec.fail(e);
-    }
-  }
 };
 
 
@@ -1338,6 +1310,114 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
 }
 
 
+////////////////////
+// Module Exports //
+////////////////////
+
+
+//
+// Export Frisby Matchers (to be used in unit tests; to be applied in toss()'s beforeEach')
+//
+exports.matchers = {
+  toMatchOrBeNull: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        return {
+          pass: (new RegExp(expected).test(actual)) || (actual === null)
+        }
+      }
+    }
+  },
+  toMatchOrBeEmpty: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        return {
+          pass: (new RegExp(expected).test(actual)) || (actual === null) || (actual === "")
+        }
+      }
+    }
+  },
+  toBeType: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        var aType = _toType(actual);
+        var eType = _toType(expected);
+        // Function is not a valid JSON type
+        if("function" === eType) {
+          eType = _toType(expected.prototype);
+        }
+        return {
+          pass: aType === eType
+        }
+      }
+    }
+  },
+  toBeTypeOrNull: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        var aType = _toType(actual);
+        var eType = _toType(expected);
+        // Function is not a valid JSON type
+        if("function" === eType) {
+          eType = _toType(expected.prototype);
+        }
+        return {
+          pass: (actual === null) || (_toType(actual) === eType)
+        }
+      }
+    }
+  },
+  toBeTypeOrUndefined: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        var aType = _toType(actual);
+        var eType = _toType(expected);
+        // Function is not a valid JSON type
+        if("function" === eType) {
+          eType = _toType(expected.prototype);
+        }
+        return {
+          pass: (actual === undefined) || (_toType(actual) === eType)
+        }
+      }
+    }
+  },
+  toContainJson: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        // Way of allowing custom failure message - by throwing exceptions in utility function
+        try {
+          return {
+            pass: _jsonContains(actual, expected)
+          };
+        } catch(e) {
+          return {
+            pass: false
+          };
+        }
+      }
+    }
+  },
+  toContainJsonTypes: function(util, customEqualityTester) {
+    return {
+      compare: function(actual, expected) {
+        // Way of allowing custom failure message - by throwing exceptions in utility function
+        try {
+          return {
+            pass: _jsonContainsTypes(actual, expected)
+          };
+        } catch(e) {
+          // Fail test if there is a match failure and it is not an inverse test (for non-match)
+          return {
+            pass: false
+          };
+        }
+      }
+    }
+  }
+}
+
+
 //
 // Main Frisby method used to start new spec tests
 //
@@ -1349,4 +1429,4 @@ exports.withPath = _withPath;
 
 // Public methods and properties
 exports.globalSetup = globalSetup;
-exports.version = '0.8.3';
+exports.version = '0.8.4';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frisby",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Frisby.js: REST API Endpoint Testing built on Jasmine",
   "homepage": "http://frisbyjs.com",
   "author": "Vance Lucas <vance@vancelucas.com>",
@@ -24,7 +24,7 @@
     "frisby"
   ],
   "dependencies": {
-    "request": ">=2.0.0 <2.50",
+    "request": ">=2.51",
     "jsonschema": "1.0.0",
     "stack-trace": "0.0.x",
     "mock-request": ">= 0.1.2",
@@ -33,14 +33,14 @@
     "qs": "1.2.x"
   },
   "devDependencies": {
-    "jasmine-node": "~1.14.5",
-    "form-data": "~0.1.4"
+    "form-data": "~0.1.4",
+    "minijasminenode2": "^1.0.0"
   },
   "main": "./lib/frisby",
   "engines": {
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "jasmine-node spec/"
+    "test": "minijasminenode2 spec/*.js"
   }
 }

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -7,6 +7,7 @@ describe('Frisby object setup', function() {
       request: {
         headers: {},
         inspectOnFailure: false,
+        inspectOnFailureRequest: false,
         json: false
       }
     }).toEqual(frisby.globalSetup());
@@ -18,6 +19,7 @@ describe('Frisby object setup', function() {
     expect({
       headers: {},
       inspectOnFailure: false,
+      inspectOnFailureRequest: false,
       json: false
     }).toEqual(f1.current.request);
   });
@@ -49,6 +51,7 @@ describe('Frisby object setup', function() {
       request: {
         headers: {},
         inspectOnFailure: false,
+        inspectOnFailureRequest: false,
         json: false
       }
     }).toEqual(frisby.globalSetup());
@@ -138,6 +141,52 @@ describe('Frisby object setup', function() {
     expect(frisby.create('mytest').get('/path', {
       inspectOnFailure: false
     }).current.outgoing.inspectOnFailure).toEqual(false);
+  });
+
+  it('should switch to inspectOnFailure and inspectOnFailureRequest default = true when global config is configured inspectOnFailure and with inspectOnFailureRequest', function() {
+    frisby.globalSetup({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectOnFailureRequest: true,
+        json: false
+      }
+    });
+
+    expect({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectOnFailureRequest: true,
+        json: false
+      }
+    }).toEqual(frisby.globalSetup());
+
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).toEqual(true);
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailureRequest).toEqual(true);
+  });
+
+  it('should switch to inspectOnFailure default = true and inspectOnFailureRequest is false when global config is configured inspectOnFailure', function() {
+    frisby.globalSetup({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectOnFailureRequest: false,
+        json: false
+      }
+    });
+
+    expect({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectOnFailureRequest: false,
+        json: false
+      }
+    }).toEqual(frisby.globalSetup());
+
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).toEqual(true);
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailureRequest).toEqual(false);
   });
 
 });

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -8,7 +8,8 @@ describe('Frisby object setup', function() {
         headers: {},
         inspectOnFailure: false,
         inspectOnFailureRequest: false,
-        json: false
+        json: false,
+        baseUri: ''
       }
     }).toEqual(frisby.globalSetup());
   });
@@ -20,7 +21,8 @@ describe('Frisby object setup', function() {
       headers: {},
       inspectOnFailure: false,
       inspectOnFailureRequest: false,
-      json: false
+      json: false,
+      baseUri: ''
     }).toEqual(f1.current.request);
   });
 
@@ -52,7 +54,8 @@ describe('Frisby object setup', function() {
         headers: {},
         inspectOnFailure: false,
         inspectOnFailureRequest: false,
-        json: false
+        json: false,
+        baseUri: ''
       }
     }).toEqual(frisby.globalSetup());
 

--- a/spec/frisby_matchers_spec.js
+++ b/spec/frisby_matchers_spec.js
@@ -1,8 +1,11 @@
 var frisby = require('../lib/frisby');
-var mockRequest = require('mock-request')
-
+var mockRequest = require('mock-request');
 
 describe('Frisby matchers', function() {
+
+  beforeEach(function(){
+    jasmine.addMatchers(frisby.matchers);
+  });
 
   it('toContainJSON should match exactly', function() {
     // Set fake JSON body

--- a/spec/frisby_mock_request_spec.js
+++ b/spec/frisby_mock_request_spec.js
@@ -81,14 +81,14 @@ describe('Frisby matchers', function() {
       .toss();
   });
 
-  it('gloablSetup should set timeout to 3000', function() {
+  it('globalSetup should set timeout to 3000', function() {
     mockGlobalSetup();
     var f1 = frisby.create(this.description)
     expect(f1.timeout()).toBe(3000);
     restoreGlobalSetup();
   });
 
-  it('gloablSetup should set local request headers', function() {
+  it('globalSetup should set local request headers', function() {
     // Mock API
     var mockFn = mockRequest.mock()
     .get('/test-object-array')
@@ -110,7 +110,7 @@ describe('Frisby matchers', function() {
       .toss();
   });
 
-  it('addHeaders should override gloablSetup request headers', function() {
+  it('addHeaders should override globalSetup request headers', function() {
     // Mock API
     var mockFn = mockRequest.mock()
     .get('/test-object-array')
@@ -663,7 +663,7 @@ describe('Frisby matchers', function() {
     // Intercepted with 'nock'
     frisby.create(this.description)
       .post('http://httpbin.org/raw', {}, {
-        body: 'some body here',
+        body: 'some body here'
       })
       .expectStatus(200)
       .expectBodyContains('some body here')
@@ -684,7 +684,7 @@ describe('Frisby matchers', function() {
       .expectHeader('Content-Type', 'application/json')
       .after(function(err, res, body) {
         expect(this.current.outgoing.headers['content-type']).toBe('application/json');
-        expect(this.current.outgoing.body).toBe('{}');
+        expect(this.current.outgoing.body).toEqual({});
       })
     .toss();
   });
@@ -700,5 +700,31 @@ describe('Frisby matchers', function() {
       .expectStatus(201)
       .expectHeaderToMatch('location', /^\/path\/\d+$/)
       .toss();
+  });
+
+  it('globalSetup should be able to set baseURI', function() {
+    nock('http://httpbin.org', { allowUnmocked: true })
+     .post('/test')
+     .once()
+     .reply(200, function(uri, requestBody) {
+       return requestBody;
+     });
+
+    frisby.globalSetup({
+      request: {
+        baseUri: 'http://httpbin.org'
+      }
+    });
+
+    frisby.create(this.description)
+      .post('/test', {}, {
+        body: 'some body here'
+      })
+      .expectStatus(200)
+      .expectBodyContains('some body here')
+      .after(function() {
+        expect(this.current.outgoing.uri).toBe('http://httpbin.org/test');
+      })
+    .toss();
   });
 });

--- a/spec/frisby_withpath_spec.js
+++ b/spec/frisby_withpath_spec.js
@@ -2,6 +2,11 @@ var frisby = require('../lib/frisby');
 
 describe('Frisby withPath syntax', function() {
 
+  // Manually add Frisby matchers (otherwise done in toss())
+  beforeEach(function(){
+    jasmine.addMatchers(frisby.matchers);
+  });
+
   it('should work with single string path', function() {
     frisby.withPath('response', {
         response: {


### PR DESCRIPTION
...est for debugging and/or troubleshooting


when have a lots of tests running is hard to detect what cause the issue and sometimes is better to get the request information to try to reproduce and debugging