### PR TITLE
Removed JSON.stringify to prevent double stringify

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -380,7 +380,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
     // if JSON data
     if(outgoing.json) {
       outgoing.headers['content-type'] = 'application/json';
-      outgoing.body = JSON.stringify(data);
+      outgoing.body = data;
     } else if(!outgoing.body) {
       if(data instanceof Buffer) {
         outgoing.body = data;


### PR DESCRIPTION
requestjs applies JSON.stringify to the request body when json option is true. Stringifying from this module makes the requestjs to send request body as "{}" instead of {} making the server throw "invalid json" when bodyparser module is used.

I just removed JSON.stringify in this module to fix the issue.