### PR TITLE
Add pending tests functionality

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -161,6 +161,8 @@ function Frisby(msg) {
     itInfo: null,
     it: null,
     isNot: false, // For Jasmine test negation
+    pending: null,
+    failPending: null,
     expects: [],
     after: [],
     retry: _gs.retry || 0,
@@ -967,6 +969,12 @@ Frisby.prototype.waits = function(millis) {
   return this;
 }
 
+Frisby.prototype.pending = function(failed) {
+  this.current.pending = true;
+  this.current.failPending = failed;
+  return this;
+}
+
 // Callback function to run after test is completed
 Frisby.prototype.after = function(cb) {
   var self = this;
@@ -1037,138 +1045,149 @@ Frisby.prototype.toss = function(retry) {
     retry = self.current.retry;
   }
 
-  // Assemble all Jasmine tests and RUN them!
-  describe('Frisby Test: ' + self.current.describe, function() {
-
-    // Add custom matchers to spec
-    beforeEach(function(){
-      jasmine.addMatchers(exports.matchers);
+  if (self.current.pending) {
+    describe('Pending Frisby Test: ' + self.current.describe, function() {
+      // Spec test
+      it("\n\t[ " + self.current.itInfo + " ] - [Pending]", function() {
+        if (self.current.failPending) {
+          expect(true).toBe(false);
+        };
+      });
     });
+  } else {
+    // Assemble all Jasmine tests and RUN them!
+    describe('Frisby Test: ' + self.current.describe, function() {
 
-    // Spec test (async: beware of jasmine's default 5sec timeout for async spec's)
-    it("\n\t[ " + self.current.itInfo + " ]", function(done) {
-      // Ensure "it" scope is accessible to tests
-      var it = this;
+      // Add custom matchers to spec
+      beforeEach(function(){
+        jasmine.addMatchers(exports.matchers);
+      });
 
-      // results_ seems to no long exsist on jasmine2.0, mock it
-      it.results_ = {
-        failedCount: 0
-      };
+      // Spec test (async: beware of jasmine's default 5sec timeout for async spec's)
+      it("\n\t[ " + self.current.itInfo + " ]", function(done) {
+        // Ensure "it" scope is accessible to tests
+        var it = this;
 
-      // launch request
-      // repeat request for self.current.retry times if request does not respond with self._timeout ms (except for POST requests)
-      var tries = 0;
-      var retries = (self.current.outgoing.method.toUpperCase() == "POST") ? 0 : self.current.retry;
+        // results_ seems to no long exsist on jasmine2.0, mock it
+        it.results_ = {
+          failedCount: 0
+        };
 
-      // wait optinally, launch request
-      if (self.current.waits > 0) {
-        setTimeout(makeRequest, self.current.waits);
-      } else {
-        makeRequest();
-      }
+        // launch request
+        // repeat request for self.current.retry times if request does not respond with self._timeout ms (except for POST requests)
+        var tries = 0;
+        var retries = (self.current.outgoing.method.toUpperCase() == "POST") ? 0 : self.current.retry;
 
-
-      function makeRequest(){
-        var requestFinished = false;
-        var timeoutFinished = false;
-        tries++;
-
-        var timeoutId = setTimeout(function maxWait(){
-          timeoutFinished = true;
-          if (tries < retries+1){
-
-            it.results_.totalCount = it.results_.passedCount = it.results_.failedCount = 0;
-            it.results_.skipped = false;
-            it.results_.items_ = [];
-
-            process.stdout.write('R')
-            makeRequest();
-          } else {
-            // should abort instead (it.spec.fail ?)
-            it.results_.failedCount = 1;
-            after();
-            // assert();
-          }
-        }, self._timeout);
-
-        self.current.it(function(data) {
-          if (!timeoutFinished) {
-            clearTimeout(timeoutId);
-            assert();
-          }
-        });
-      }
-
-
-      // Assert callback
-      // called from makeRequest if request has finished successfully
-      function assert() {
-        var i;
-        self.current.expectsFailed = true;
-
-        // if you have no expects, they can't fail
-        if (self.current.expects.length == 0) {
-          retry = -1;
-          self.current.expectsFailed = false;
+        // wait optinally, launch request
+        if (self.current.waits > 0) {
+          setTimeout(makeRequest, self.current.waits);
+        } else {
+          makeRequest();
         }
 
-        // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
-        // Some 'expects' helpers add more tests when executed (recursive 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
-        for(i=0; i < self.current.expects.length; i++) {
-          if(false !== self._exceptionHandler) {
-            try {
-              self.current.expects[i].call(it);
-            } catch(e) {
-              self._exceptionHandler.call(self, e);
+
+        function makeRequest(){
+          var requestFinished = false;
+          var timeoutFinished = false;
+          tries++;
+
+          var timeoutId = setTimeout(function maxWait(){
+            timeoutFinished = true;
+            if (tries < retries+1){
+
+              it.results_.totalCount = it.results_.passedCount = it.results_.failedCount = 0;
+              it.results_.skipped = false;
+              it.results_.items_ = [];
+
+              process.stdout.write('R')
+              makeRequest();
+            } else {
+              // should abort instead (it.spec.fail ?)
+              it.results_.failedCount = 1;
+              after();
+              // assert();
             }
-          } else {
-            self.current.expects[i].call(it);
+          }, self._timeout);
+
+          self.current.it(function(data) {
+            if (!timeoutFinished) {
+              clearTimeout(timeoutId);
+              assert();
+            }
+          });
+        }
+
+
+        // Assert callback
+        // called from makeRequest if request has finished successfully
+        function assert() {
+          var i;
+          self.current.expectsFailed = true;
+
+          // if you have no expects, they can't fail
+          if (self.current.expects.length == 0) {
+            retry = -1;
+            self.current.expectsFailed = false;
           }
-        }
-
-        if (it.results_.failedCount == 0) {
-          retry = -1;
-          self.current.expectsFailed = false;
-        }
-
-        // call after()
-        after();
-      }
-
-      // AFTER callback (execute further expects for the current spec)
-      // called from assert()
-      function after() {
-        if(self.current.after) {
-
-          if (self.current.expectsFailed && self.current.outgoing.inspectOnFailure) {
-            console.log(self.current.itInfo + ' has FAILED with the following response:');
-            self.inspectStatus();
-            self.inspectJSON();
-          };
 
           // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
-          // this enables after to add more after to do things (like inspectJSON)
-          for(i=0; i < self.current.after.length; i++) {
-            var fn = self.current.after[i];
+          // Some 'expects' helpers add more tests when executed (recursive 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
+          for(i=0; i < self.current.expects.length; i++) {
             if(false !== self._exceptionHandler) {
               try {
-                fn.call(self);
+                self.current.expects[i].call(it);
               } catch(e) {
-                self._exceptionHandler(e);
+                self._exceptionHandler.call(self, e);
               }
             } else {
-              fn.call(self);
+              self.current.expects[i].call(it);
             }
           }
+
+          if (it.results_.failedCount == 0) {
+            retry = -1;
+            self.current.expectsFailed = false;
+          }
+
+          // call after()
+          after();
         }
 
-        // finally call done to finish spec
-        done();
-      }
+        // AFTER callback (execute further expects for the current spec)
+        // called from assert()
+        function after() {
+          if(self.current.after) {
+
+            if (self.current.expectsFailed && self.current.outgoing.inspectOnFailure) {
+              console.log(self.current.itInfo + ' has FAILED with the following response:');
+              self.inspectStatus();
+              self.inspectJSON();
+            };
+
+            // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
+            // this enables after to add more after to do things (like inspectJSON)
+            for(i=0; i < self.current.after.length; i++) {
+              var fn = self.current.after[i];
+              if(false !== self._exceptionHandler) {
+                try {
+                  fn.call(self);
+                } catch(e) {
+                  self._exceptionHandler(e);
+                }
+              } else {
+                fn.call(self);
+              }
+            }
+          }
+
+          // finally call done to finish spec
+          done();
+        }
+
+      });
 
     });
-
-  });
+  };
 };
 
 


### PR DESCRIPTION
Hi,

 Here is some small changes to add the ability to define pending tests, functionality is implemented by allowing to chain a call to "pending()" function when creating the frisby test case, this function allows a parameter to define if pending tests should fail or pass.
 Once jasmine is updated to 2.0 it should be easy to update functionality to work with its own pending state.

 I am not sure if this change would require some tests (and not sure how to implement those if they are), any ideas?

 Regards,
