### PR TITLE
Load JSON Schema files globally

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -41,6 +41,14 @@ var globalSetup = function(opts) {
   return _frisbyGlobalSetup;
 };
 
+var _schemaValidator = new JSONSchemaValidator()
+
+// Load schemas globally
+var loadJSONSchema = function(obj) {
+  for (var prop in obj) {
+    _schemaValidator.addSchema(obj[prop], prop)
+  }
+}
 
 var _toType = function(obj) {
   return ({}).toString.call(obj).match(/\s([a-z|A-Z]+)/)[1].toLowerCase();
@@ -744,7 +752,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
     var jsonBody = _jsonParse(self.current.response.body);
     // With path syntax
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
-      var jsVal = new JSONSchemaValidator();
+      var jsVal = _schemaValidator || new JSONSchemaValidator();
       var res = jsVal.validate(jsonChunk, jsonSchema);
       if(res.valid === true) {
         // Use assertion to keep assertion count accurate
@@ -1342,4 +1350,5 @@ exports.withPath = _withPath;
 
 // Public methods and properties
 exports.globalSetup = globalSetup;
+exports.loadJSONSchema = loadJSONSchema;
 exports.version = '0.8.3';


### PR DESCRIPTION
Schemas can have references to other schemas. This change lets us load the required schemas in advance making them available when needed.

```js
frisby.loadJSONSchema({
  "product": productSchema,
  "item": ItemSchema
});
```

For example, wherever a schema references (`$refs`), `"product"`, `productSchema` will be substituted. Partly addresses #100 although the schemas still need to loaded manually.