### PR TITLE
Adding Configuration option to control content type override is json mod...

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -26,7 +26,9 @@ var _frisbyGlobalSetup = {
     headers: {},
     inspectOnFailure: false,
     json: false,
-    baseUri: ''
+    baseUri: '',
+    overRideContentType: true
+
   }
 };
 var globalSetup = function(opts) {
@@ -38,6 +40,7 @@ var globalSetup = function(opts) {
       _frisbyGlobalSetup.request.inspectOnFailure = false;
       _frisbyGlobalSetup.request.json = false;
       _frisbyGlobalSetup.request.baseUri = '';
+      _frisbyGlobalSetup.request.overRideContentType = true;
     }
   }
   return _frisbyGlobalSetup;
@@ -387,7 +390,9 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   if (data) {
     // if JSON data
     if(outgoing.json) {
-      outgoing.headers['content-type'] = 'application/json';
+      if (_frisbyGlobalSetup.request.overRideContentType) {
+        outgoing.headers['content-type'] = 'application/json';
+      }
       outgoing.body = data;
     } else if(!outgoing.body) {
       if(data instanceof Buffer) {

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -8,7 +8,8 @@ describe('Frisby object setup', function() {
         headers: {},
         inspectOnFailure: false,
         json: false,
-        baseUri: ''
+        baseUri: '',
+        overRideContentType: true
       }
     }).toEqual(frisby.globalSetup());
   });
@@ -20,7 +21,8 @@ describe('Frisby object setup', function() {
       headers: {},
       inspectOnFailure: false,
       json: false,
-      baseUri: ''
+      baseUri: '',
+      overRideContentType: true
     }).toEqual(f1.current.request);
   });
 
@@ -52,7 +54,8 @@ describe('Frisby object setup', function() {
         headers: {},
         inspectOnFailure: false,
         json: false,
-        baseUri: ''
+        baseUri: '',
+        overRideContentType: true
       }
     }).toEqual(frisby.globalSetup());
 


### PR DESCRIPTION
...e

This is fixing issue #187 by allowing control over if the content type should be over-ridden when raw JSON is set to the body. - We had the same problem in which the backend service insisted on content-type 'text/plain' even when requesting JSON data
