### PR TITLE
Fix #65: Add ttoss() to support run single tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 /node_modules
 npm-debug.log
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ frisby.create('GET user johndoe')
 
 Any of the [Jasmine matchers](https://github.com/pivotal/jasmine/wiki/Matchers) can be used inside the `after` and `afterJSON` callbacks to perform additional or custom tests on the response data.
 
+To run only one of the tests, replace `toss` to `ttoss`.
+
 ## Running Tests
 
 Frisby is built on top of the jasmine BDD spec framework, and uses the excellent [jasmine-node test runner](https://github.com/mhevery/jasmine-node) to run spec tests in a specified target directory.  

--- a/examples/one_frisby_test_spec.js
+++ b/examples/one_frisby_test_spec.js
@@ -1,0 +1,24 @@
+/**
+ * frisby.js: how to run only one frisby test
+ * DO NOT RUN THIS WITH OTHERS TESTS, THIS WILL DISABLE OTHER TESTS
+ *
+ * Author: He Sicong
+ */
+
+var frisby = require('../lib/frisby');
+
+frisby.globalSetup({
+    request: {
+        headers:{'Accept': 'application/json'}
+    }
+});
+
+frisby.create('Should only run this test')
+    .get('https://graph.facebook.com/111848702235277')
+    .expectStatus(200)
+    .ttoss();
+
+frisby.create('Should NOT run this failed test')
+    .get('https://graph.facebook.com/111848702235277')
+    .expectStatus(400)
+    .toss();

--- a/examples/one_frisby_test_spec.js
+++ b/examples/one_frisby_test_spec.js
@@ -13,12 +13,12 @@ frisby.globalSetup({
     }
 });
 
-frisby.create('Should only run this test')
-    .get('https://graph.facebook.com/111848702235277')
-    .expectStatus(200)
-    .ttoss();
-
 frisby.create('Should NOT run this failed test')
     .get('https://graph.facebook.com/111848702235277')
     .expectStatus(400)
     .toss();
+
+frisby.create('Should only run this test')
+    .get('https://graph.facebook.com/111848702235277')
+    .expectStatus(200)
+    .ttoss();

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -1027,18 +1027,20 @@ Frisby.prototype.setResponseHeader = function(key, value) {
   return this.current.response.headers[key.toLowerCase()];
 };
 
+Frisby.prototype.ttoss = function(retry){
+  return this.toss(retry, true);
+};
 
 //
 // Toss (Run the current Frisby test)
 //
-Frisby.prototype.toss = function(retry) {
+Frisby.prototype.toss = function(retry, only) {
   var self = this;
   if (typeof retry === "undefined") {
     retry = self.current.retry;
   }
 
-  // Assemble all Jasmine tests and RUN them!
-  describe('Frisby Test: ' + self.current.describe, function() {
+  var describeFunc = function() {
 
     // Add custom matchers to spec
     beforeEach(function(){
@@ -1167,8 +1169,14 @@ Frisby.prototype.toss = function(retry) {
       }
 
     });
+  };
 
-  });
+  // Assemble all Jasmine tests and RUN them!
+  if (only) {
+    ddescribe('Frisby Test: ' + self.current.describe, describeFunc);
+  } else {
+    describe('Frisby Test: ' + self.current.describe, describeFunc);
+  }
 };
 
 


### PR DESCRIPTION
Add new ttoss() or use toss(false, false) to run single tests.