### PR TITLE
Set body to `undefined` for request@>2.52

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -351,7 +351,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       outgoing = {
         json: params.json || (_frisbyGlobalSetup && _frisbyGlobalSetup.request && _frisbyGlobalSetup.request.json || false),
         uri: null,
-        body: params.body || null,
+        body: params.body || undefined,
         method: 'GET',
         headers: {}
       };


### PR DESCRIPTION
This prevents the error "Cannot call method 'replace' of null"

Fixes vlucas/frisby#192