### PR TITLE
Bugfix - exception when matching cookie header

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -501,7 +501,7 @@ Frisby.prototype.expectHeader = function(header, content) {
   var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
     if(typeof self.current.response.headers[header] !== "undefined") {
-      expect(self.current.response.headers[header].toLowerCase()).toEqual(content.toLowerCase());
+      expect((self.current.response.headers[header]+"").toLowerCase()).toEqual(content.toLowerCase());
     } else {
       throw new Error("Header '" + header + "' not present in HTTP response");
     }
@@ -515,7 +515,7 @@ Frisby.prototype.expectHeaderContains = function(header, content) {
   var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
     if(typeof self.current.response.headers[header] !== "undefined") {
-      expect(self.current.response.headers[header].toLowerCase()).toContain(content.toLowerCase());
+      expect((self.current.response.headers[header]+"").toLowerCase()).toContain(content.toLowerCase());
     } else {
       throw new Error("Header '" + header + "' not present in HTTP response");
     }
@@ -529,7 +529,7 @@ Frisby.prototype.expectHeaderToMatch = function(header, pattern) {
     var header = (header+"").toLowerCase();
     this.current.expects.push(function() {
         if(typeof self.current.response.headers[header] !== "undefined") {
-            expect(self.current.response.headers[header].toLowerCase()).toMatch(pattern);
+            expect((self.current.response.headers[header]+"").toLowerCase()).toMatch(pattern);
         } else {
             throw new Error("Header '" + header + "' does not match pattern '" + pattern + "' in HTTP response");
         }

--- a/spec/frisby_httpbin_spec.js
+++ b/spec/frisby_httpbin_spec.js
@@ -421,5 +421,14 @@ describe('Frisby live running httpbin tests', function() {
       })
       .toss();
 
-  })
+  });
+
+  it('should handle multiple cookies in the header', function() {
+    frisby.create('test with httpbin for handling multiple cookies')
+        .get('http://httpbin.org/cookies/set?k1=v1&k2=v2', { followRedirect: false, maxRedirects: 1 })
+        .expectHeader('set-cookie', "k2=v2; path=/,k1=v1; path=/")
+        .expectHeaderContains('set-cookie', 'k2=v2')
+        .expectHeaderToMatch('set-cookie', /path=\//)
+        .toss();
+  });
 });


### PR DESCRIPTION
Underlying http library may parse cookies into an array, but Frisby assumes that it's a string and calls .toLowerCase() on it, causing a No Method Exception.

Fixed by coercing the array into a string using the +"" idiom already used by the library.  Not a huge fan of that, but it's best to stick with one style inside a library.

This PR is against the release-fix branch, as Master seems to be broken.

Fixes #218 
