### PR TITLE
Fixes of issue #210 (_jsonParse leaks 'json' to the global scope)

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -1165,7 +1165,7 @@ Frisby.prototype.toss = function(retry) {
 // Parse body as JSON, ensuring not to re-parse when body is already an object (thanks @dcaylor)
 //
 function _jsonParse(body) {
-  json = "";
+  var json = "";
   try {
     json = (typeof body === "object") ? body : JSON.parse(body);
   } catch(e) {


### PR DESCRIPTION
The function _jsonParse leaks the variable json to the global scope because it is missing the var keyword. Robert Herhold holds the credit of this pull request