### PR TITLE
Add path to error msg in jsonContainsTypes

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -601,7 +601,7 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
     // EACH item in array should match
     if("*" === type || "&" === type) {
       _.each(jsonBody, function(json) {
-        expect(json).toContainJsonTypes(jsonTest, self.current.isNot);
+        expect(json).toContainJsonTypes(jsonTest, self.current.isNot, path);
       });
 
     // ONE item in array should match
@@ -612,7 +612,7 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
 
       for(var i = 0; i < itemCount; i++) {
         try {
-          var result = _jsonContainsTypes(jsonBody[i], jsonTest, self.current.isNot);
+          var result = _jsonContainsTypes(jsonBody[i], jsonTest, /*self.current.isNot*/ path);
         } catch (e) {
           errorCount++;
           errorLast = e;
@@ -630,7 +630,7 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
 
     // Normal matcher
     } else {
-      expect(jsonBody).toContainJsonTypes(jsonTest, self.current.isNot);
+      expect(jsonBody).toContainJsonTypes(jsonTest, self.current.isNot, path);
     }
   });
   return this;
@@ -1191,14 +1191,14 @@ jasmine.Matchers.prototype.toContainJson = function(expected, isNot) {
     }
   }
 };
-jasmine.Matchers.prototype.toContainJsonTypes = function(expected, isNot) {
+jasmine.Matchers.prototype.toContainJsonTypes = function(expected, isNot, path) {
   this.message = function() {
     return "Actual JSON types did not match expected";
   }
 
   // Way of allowing custom failure message - by throwing exceptions in utility function
   try {
-    return _jsonContainsTypes(this.actual, expected);
+    return _jsonContainsTypes(this.actual, expected, path);
   } catch(e) {
     // Fail test if there is a match failure and it is not an inverse test (for non-match)
     if(!this.isNot && !isNot) {
@@ -1287,7 +1287,7 @@ function _jsonContains(jsonBody, jsonTest) {
 }
 
 
-function _jsonContainsTypes(jsonBody, jsonTest) {
+function _jsonContainsTypes(jsonBody, jsonTest, path) {
   // Check each matching key/val
   var errorKeys = [];
   for(key in jsonTest) {
@@ -1302,7 +1302,7 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
           var res = jsonTest[key](jsonBody[key]);
           if(typeof res === "boolean") {
             if(true !== res) {
-              throw new Error("Expected callback function on key '" + key + "' to return true");
+              throw new Error("Expected callback function on key '" + key + "' in path " + path + " to return true");
             }
           }
           // Don't do any further assertions for user
@@ -1312,7 +1312,7 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
         }
       } else if(kt === "object") {
         // NESTED expectJSON
-        _jsonContainsTypes(jsonBody[key], jsonTest[key]);
+        _jsonContainsTypes(jsonBody[key], jsonTest[key], path);
         continue;
       }
 
@@ -1324,7 +1324,7 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
         eType = _toType(jsonTest[key].prototype);
       }
       if(aType !== eType) {
-        throw new Error("Expected '" + aType + "' to be type '" + eType + "' on key '" + key + "'");
+        throw new Error("Expected '" + aType + "' to be type '" + eType + "' on key '" + key + "' in path '" + path + "'");
       }
 
       // Do an assertion so assertion count will be consistent
@@ -1332,7 +1332,7 @@ function _jsonContainsTypes(jsonBody, jsonTest) {
   };
 
   if(errorKeys.length > 0) {
-    throw new Error("Keys ['" + errorKeys.join("', '") + "'] not present in JSON Response body");
+    throw new Error("Keys ['" + errorKeys.join("', '") + "'] in path '" + path + "' not present in JSON Response body");
   }
 
   return true;


### PR DESCRIPTION
I just started using your module a day or so ago, and quickly realized that I wasn't getting enough information (from the errors) with the tests I was running on my API. Each of my API endpoints has a lot of (side-loaded) data coming out of it, which in turn made it hard to tell which objects where getting the errors. For instance, my test looks like this:

``` javascript
frisby.create('clients')
    .get( config.endpoint + '/clients' )
    .expectStatus(200)
    .expectJSONTypes('clients.?', object.client)
    .expectJSONTypes('clients.0.settings', object.clientSettings)
    .expectJSONTypes('clients.0.events.?', object.event)
    .expectJSONTypes('clients.0.events.0.settings', object.eventSettings)
    .expectJSONTypes('clients.0.events.0.attendees.?', object.attendee)
    .expectJSONTypes('clients.0.events.0.languages.?', object.language)
    .expectJSONTypes('clients.0.events.0.features.?', object.feature)
    .expectJSONTypes('clients.0.events.0.modes.?', object.mode)
    .expectJSONTypes('clients.0.events.0.modes.0.settings', object.modeSettings)
    .expectJSONTypes('clients.0.events.0.shares.?', object.share)
    .expectJSONTypes('clients.0.events.0.signups.?', object.signup)
.toss();
```

And the output I was getting was:

![screen shot 2015-06-11 at 1 11 11 pm](https://cloud.githubusercontent.com/assets/689046/8117361/6b4b9404-103c-11e5-88e7-dd502838f24d.png)

Each one of the above 11 objects has an `id` key on it, so how would I know where there error was (without having to dig through my output manually). So I made a small change to your methods to pass the `path` along down to where the error text is generated. Now you get something like this:

![screen shot 2015-06-11 at 1 12 00 pm](https://cloud.githubusercontent.com/assets/689046/8117397/a8cfbb66-103c-11e5-8801-38d46666f2e2.png)

I've applied it only to this one method for now, but ideally it could be applied to all the errors for consistency.

Also, one thing to note, you will notice in the commit changes that I commented out `self.current.isNot` in the arguments for `_jsonContainsTypes` on line 615. I wasn't sure why this was being passed to that method (it doesn't appear to be getting used at all)... If it is though, a minor fix may need to be applied.
