### PR TITLE
Inspect headers and request on Failure

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -25,6 +25,7 @@ var _frisbyGlobalSetup = {
   request: {
     headers: {},
     inspectOnFailure: false,
+    inspectRequestOnFailure: false,
     json: false,
     baseUri: ''
   }
@@ -36,6 +37,7 @@ var globalSetup = function(opts) {
       _frisbyGlobalSetup.request = {};
       _frisbyGlobalSetup.request.headers = {};
       _frisbyGlobalSetup.request.inspectOnFailure = false;
+      _frisbyGlobalSetup.request.inspectRequestOnFailure = false;
       _frisbyGlobalSetup.request.json = false;
       _frisbyGlobalSetup.request.baseUri = '';
     }
@@ -1135,6 +1137,10 @@ Frisby.prototype.toss = function(retry, only) {
             console.log(self.current.itInfo + ' has FAILED with the following response:');
             self.inspectStatus();
             self.inspectJSON();
+            if(self.current.outgoing.inspectRequestOnFailure) {
+              self.inspectRequest();
+              self.inspectHeaders();
+            }
           };
 
           // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -25,7 +25,6 @@ var _frisbyGlobalSetup = {
   request: {
     headers: {},
     inspectOnFailure: false,
-    inspectRequestOnFailure: false,
     json: false,
     baseUri: ''
   }
@@ -37,7 +36,6 @@ var globalSetup = function(opts) {
       _frisbyGlobalSetup.request = {};
       _frisbyGlobalSetup.request.headers = {};
       _frisbyGlobalSetup.request.inspectOnFailure = false;
-      _frisbyGlobalSetup.request.inspectRequestOnFailure = false;
       _frisbyGlobalSetup.request.json = false;
       _frisbyGlobalSetup.request.baseUri = '';
     }
@@ -1135,12 +1133,10 @@ Frisby.prototype.toss = function(retry, only) {
 
           if (self.current.expectsFailed && self.current.outgoing.inspectOnFailure) {
             console.log(self.current.itInfo + ' has FAILED with the following response:');
+            self.inspectHeaders();
+            self.inspectRequest();
             self.inspectStatus();
             self.inspectJSON();
-            if(self.current.outgoing.inspectRequestOnFailure) {
-              self.inspectRequest();
-              self.inspectHeaders();
-            }
           };
 
           // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -7,7 +7,6 @@ describe('Frisby object setup', function() {
       request: {
         headers: {},
         inspectOnFailure: false,
-        inspectRequestOnFailure: false,
         json: false,
         baseUri: ''
       }
@@ -20,7 +19,6 @@ describe('Frisby object setup', function() {
     expect({
       headers: {},
       inspectOnFailure: false,
-      inspectRequestOnFailure: false,
       json: false,
       baseUri: ''
     }).toEqual(f1.current.request);
@@ -53,7 +51,6 @@ describe('Frisby object setup', function() {
       request: {
         headers: {},
         inspectOnFailure: false,
-        inspectRequestOnFailure: false,
         json: false,
         baseUri: ''
       }
@@ -146,49 +143,4 @@ describe('Frisby object setup', function() {
     }).current.outgoing.inspectOnFailure).toEqual(false);
   });
 
-  it('should switch to inspectOnFailure and inspectRequestOnFailuredefault = true when global config is configured inspectOnFailure and with inspectRequestOnFailure', function() {
-    frisby.globalSetup({
-      request: {
-        headers: {},
-        inspectOnFailure: true,
-        inspectRequestOnFailure: true,
-        json: false
-      }
-    });
-
-    expect({
-      request: {
-        headers: {},
-        inspectOnFailure: true,
-        inspectRequestOnFailure: true,
-        json: false
-      }
-    }).toEqual(frisby.globalSetup());
-
-    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).toEqual(true);
-    expect(frisby.create('mytest').get('/path').current.outgoing.inspectRequestOnFailure).toEqual(true);
-  });
-
-  it('should switch to inspectOnFailure default = true and inspectRequestOnFailure is false when global config is configured inspectOnFailure', function() {
-    frisby.globalSetup({
-      request: {
-        headers: {},
-        inspectOnFailure: true,
-        inspectRequestOnFailure: false,
-        json: false
-      }
-    });
-
-    expect({
-      request: {
-        headers: {},
-        inspectOnFailure: true,
-        inspectRequestOnFailure: false,
-        json: false
-      }
-    }).toEqual(frisby.globalSetup());
-
-    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).toEqual(true);
-    expect(frisby.create('mytest').get('/path').current.outgoing.inspectRequestOnFailure).toEqual(false);
-  });
 });

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -7,6 +7,7 @@ describe('Frisby object setup', function() {
       request: {
         headers: {},
         inspectOnFailure: false,
+        inspectRequestOnFailure: false,
         json: false,
         baseUri: ''
       }
@@ -19,6 +20,7 @@ describe('Frisby object setup', function() {
     expect({
       headers: {},
       inspectOnFailure: false,
+      inspectRequestOnFailure: false,
       json: false,
       baseUri: ''
     }).toEqual(f1.current.request);
@@ -51,6 +53,7 @@ describe('Frisby object setup', function() {
       request: {
         headers: {},
         inspectOnFailure: false,
+        inspectRequestOnFailure: false,
         json: false,
         baseUri: ''
       }
@@ -143,4 +146,49 @@ describe('Frisby object setup', function() {
     }).current.outgoing.inspectOnFailure).toEqual(false);
   });
 
+  it('should switch to inspectOnFailure and inspectRequestOnFailuredefault = true when global config is configured inspectOnFailure and with inspectRequestOnFailure', function() {
+    frisby.globalSetup({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectRequestOnFailure: true,
+        json: false
+      }
+    });
+
+    expect({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectRequestOnFailure: true,
+        json: false
+      }
+    }).toEqual(frisby.globalSetup());
+
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).toEqual(true);
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectRequestOnFailure).toEqual(true);
+  });
+
+  it('should switch to inspectOnFailure default = true and inspectRequestOnFailure is false when global config is configured inspectOnFailure', function() {
+    frisby.globalSetup({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectRequestOnFailure: false,
+        json: false
+      }
+    });
+
+    expect({
+      request: {
+        headers: {},
+        inspectOnFailure: true,
+        inspectRequestOnFailure: false,
+        json: false
+      }
+    }).toEqual(frisby.globalSetup());
+
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).toEqual(true);
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectRequestOnFailure).toEqual(false);
+  });
 });


### PR DESCRIPTION
Adding again due the last had some issues in merge :(

for debugging and/or troubleshooting

when have a lots of tests running is hard to detect what cause the issue and sometimes is better to get the request information to try to reproduce and debugging

to try to improve this #148 

had issues to update https://github.com/vlucas/frisby/pull/251 then opened a new one
