### PR TITLE
Allow external json files to be loaded in through context

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -725,17 +725,15 @@ Frisby.prototype.expectJSON = function(jsonTest) {
   return this;
 };
 
-
-
-
 // Helper to validate JSON response against provided JSONSchema structure or document
-Frisby.prototype.expectJSONSchema = function(jsonSchema, context) {
+Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
+      path       = typeof args[0] === 'string' && args.shift(),
       jsonSchema = (typeof args[0] === 'object' || typeof args[0] === 'string') && args.shift();
       context = (typeof args[0] === 'object') && args.shift();
 
-  var jsVal = _schemaValidator || new JSONSchemaValidator();
+  var jsVal = new JSONSchemaValidator();
 
   // String = file path
   if(typeof jsonSchema === 'string') {
@@ -749,7 +747,6 @@ Frisby.prototype.expectJSONSchema = function(jsonSchema, context) {
     }
     var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
     jsonSchema      = JSON.parse(data);
-    jsVal.addSchema(jsonSchemaFile, jsonSchema)
   }
 
   if(context) {
@@ -773,7 +770,7 @@ Frisby.prototype.expectJSONSchema = function(jsonSchema, context) {
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
     // With path syntax
-    _withPath.call(self, null, jsonBody, function(jsonChunk) {
+    _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
       var res = jsVal.validate(jsonChunk, jsonSchema);
       if(res.valid === true) {
@@ -785,7 +782,7 @@ Frisby.prototype.expectJSONSchema = function(jsonSchema, context) {
       } else {
         // JSONSchema failures - show each one to user
         throw new Error("JSONSchema validation failed with the following errors: \n\t> " +
-          res.errors.map(function(err, field) { return err.stack; }).join("\n\t> ")
+          res.errors.map(function(err, field) { return err.stack.replace('instance', path); }).join("\n\t> ")
         );
       }
     });

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -641,7 +641,6 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
   return this;
 };
 
-
 // Helper to check parse HTTP response body as JSON and check key types
 Frisby.prototype.expectJSON = function(jsonTest) {
   var self     = this,

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -726,14 +726,24 @@ Frisby.prototype.expectJSON = function(jsonTest) {
 };
 
 // Helper to validate JSON response against provided JSONSchema structure or document
-Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
+Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_external_required) {
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
       path       = args.shift(),
       jsonSchema = args.shift();
       context = args.shift();
+      disable_external_required = args.shift();
 
   var jsVal = new JSONSchemaValidator();
+
+  if(_.isUndefined(disable_external_required)) {
+    disable_external_required = false;
+  }
+
+  // Set path value if not set
+  if(path == null || path == '' || _.isUndefined(path)) {
+      path = null;
+  }
 
   // Convert filepath of jsonSchema to an object by loading it.
   // If it is an object, we do not need to touch it.
@@ -759,22 +769,23 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
       if(!fs.existsSync(context[jsonSchemaSet])) {
         var trace       = stackTrace.parse(new Error());
         var callingFile = trace[1].getFileName();
-        var callingDir  = fspath.dirname(callingFile)
+        var callingDir  = fspath.dirname(callingFile);
         jsonSchemaFile = fspath.join(callingDir, context[jsonSchemaSet]);
       }
       var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
       jsonSchema      = JSON.parse(data);
+
+      // Remove required as jsonschema is not able to handle external requires...
+      if (disable_external_required === true) {
+        delete jsonSchema.required;
+      }
       jsVal.addSchema(jsonSchemaFile, jsonSchema)
     }
   }
 
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
-    // With path syntax. Send null for the path, not undefined as otherwise it
-    // will pass validaton without actually checking.
-    if(!_.isUndefined(path)) {
-      path = null;
-    }
+    // With path syntax.
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
       var res = jsVal.validate(jsonChunk, jsonSchema);
@@ -795,7 +806,6 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   return this;
 };
-
 
 // Helper to check parse HTTP response body as JSON and check array or object length
 Frisby.prototype.expectJSONLength = function(expectedLength) {

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -11,7 +11,7 @@ var qs = require('qs')
   , util = require('util')
   , request = require('request')
   , _ = require('underscore')
-  , JSONSchemaValidator = require('jsonschema').Validator
+  , tv4 = require('tv4')
   , stackTrace = require('stack-trace')
   , fs = require('fs')
   , fspath = require('path')
@@ -725,6 +725,7 @@ Frisby.prototype.expectJSON = function(jsonTest) {
   return this;
 };
 
+
 // Helper to validate JSON response against provided JSONSchema structure or document
 Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_external_required) {
   var self       = this,
@@ -733,8 +734,6 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_
       jsonSchema = args.shift();
       context = args.shift();
       disable_external_required = args.shift();
-
-  var jsVal = new JSONSchemaValidator();
 
   if(_.isUndefined(disable_external_required)) {
     disable_external_required = false;
@@ -770,16 +769,16 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_
         var trace       = stackTrace.parse(new Error());
         var callingFile = trace[1].getFileName();
         var callingDir  = fspath.dirname(callingFile);
-        jsonSchemaFile = fspath.join(callingDir, context[jsonSchemaSet]);
+        jsonSchemaFullPathToFile = fspath.join(callingDir, context[jsonSchemaSet]);
       }
-      var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
+      var data        = fs.readFileSync(jsonSchemaFullPathToFile, 'utf-8');
       jsonSchema      = JSON.parse(data);
 
       // Remove required as jsonschema is not able to handle external requires...
       if (disable_external_required === true) {
         delete jsonSchema.required;
       }
-      jsVal.addSchema(jsonSchemaFile, jsonSchema)
+      tv4.addSchema(jsonSchemaFile, jsonSchema);
     }
   }
 
@@ -788,7 +787,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_
     // With path syntax.
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
-      var res = jsVal.validate(jsonChunk, jsonSchema);
+      var res = tv4.validateResult(jsonChunk, jsonSchema);
       if(res.valid === true) {
         // Use assertion to keep assertion count accurate
         expect(res.valid).toBeTruthy();
@@ -797,8 +796,8 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_
         expect(res.valid).toBeFalsy();
       } else {
         // JSONSchema failures - show each one to user
-        throw new Error("JSONSchema validation failed with the following errors: \n\t> " +
-          res.errors.map(function(err, field) { return err.stack.replace('instance', path); }).join("\n\t> ")
+        throw new Error("JSONSchema validation failed with the following error: \n\t> " + res.error.message + " for dataPath " +
+          res.error.dataPath + " and with schemaPath " + res.error.schemaPath
         );
       }
     });

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -727,6 +727,7 @@ Frisby.prototype.expectJSON = function(jsonTest) {
 
 // Helper to validate JSON response against provided JSONSchema structure or document
 Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
+  console.log(path);
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
       path       = typeof args[0] === 'string' && args.shift(),
@@ -735,7 +736,8 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   var jsVal = new JSONSchemaValidator();
 
-  // String = file path
+  // Convert filepath of jsonSchema to an object by loading it.
+  // If it is an object, we do not need to touch it.
   if(typeof jsonSchema === 'string') {
     var jsonSchemaFile = jsonSchema;
     // Allows relative file paths from Frisby specs
@@ -749,11 +751,9 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
     jsonSchema      = JSON.parse(data);
   }
 
-  if(_.isUndefined(path)) {
-    path = false;
-  }
-
-  if(_.isUndefined(context)) {
+  // Convert all other filepaths in context to additonal context
+  // for the jsonschema validator to be aware of.
+  if(!_.isUndefined(context)) {
     for (var jsonSchemaSet in context) {
       var jsonSchemaFile = jsonSchemaSet;
       // Allows relative file paths from Frisby specs
@@ -774,6 +774,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
     // With path syntax
+    console.log("path" + path);
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
       var res = jsVal.validate(jsonChunk, jsonSchema);
@@ -794,6 +795,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   return this;
 };
+
 
 
 // Helper to check parse HTTP response body as JSON and check array or object length

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -726,18 +726,16 @@ Frisby.prototype.expectJSON = function(jsonTest) {
 };
 
 
+
+
 // Helper to validate JSON response against provided JSONSchema structure or document
-Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
+Frisby.prototype.expectJSONSchema = function(jsonSchema, context) {
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
-      path       = typeof args[0] === 'string' && args.shift(),
       jsonSchema = (typeof args[0] === 'object' || typeof args[0] === 'string') && args.shift();
+      context = (typeof args[0] === 'object') && args.shift();
 
-  // If called with only a single argument, ensure path is null
-  if(_.isUndefined(jsonSchema) || !jsonSchema) {
-    jsonSchema = path;
-    path = false;
-  }
+  var jsVal = _schemaValidator || new JSONSchemaValidator();
 
   // String = file path
   if(typeof jsonSchema === 'string') {
@@ -751,13 +749,32 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
     }
     var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
     jsonSchema      = JSON.parse(data);
+    jsVal.addSchema(jsonSchemaFile, jsonSchema)
+  }
+
+  if(context) {
+    for (var jsonSchemaSet in context) {
+      var jsonSchemaFile = jsonSchemaSet;
+      // Allows relative file paths from Frisby specs
+      if(!fs.existsSync(context[jsonSchemaSet])) {
+        var trace       = stackTrace.parse(new Error());
+        var callingFile = trace[1].getFileName();
+        var callingDir  = fspath.dirname(callingFile)
+        jsonSchemaFile = fspath.join(callingDir, context[jsonSchemaSet]);
+      }
+      var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
+      jsonSchema      = JSON.parse(data);
+      // Remove required as jsonschema is not able to handle external requires...
+      delete jsonSchema.required
+      jsVal.addSchema(jsonSchemaFile, jsonSchema)
+    }
   }
 
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
     // With path syntax
-    _withPath.call(self, path, jsonBody, function(jsonChunk) {
-      var jsVal = new JSONSchemaValidator();
+    _withPath.call(self, null, jsonBody, function(jsonChunk) {
+
       var res = jsVal.validate(jsonChunk, jsonSchema);
       if(res.valid === true) {
         // Use assertion to keep assertion count accurate
@@ -768,7 +785,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
       } else {
         // JSONSchema failures - show each one to user
         throw new Error("JSONSchema validation failed with the following errors: \n\t> " +
-          res.errors.map(function(err, field) { return err.stack.replace('instance', path); }).join("\n\t> ")
+          res.errors.map(function(err, field) { return err.stack; }).join("\n\t> ")
         );
       }
     });
@@ -776,6 +793,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema) {
 
   return this;
 };
+
 
 
 // Helper to check parse HTTP response body as JSON and check array or object length

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -773,7 +773,6 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
     // With path syntax
-    console.log("path" + path);
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
       var res = jsVal.validate(jsonChunk, jsonSchema);

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -727,12 +727,11 @@ Frisby.prototype.expectJSON = function(jsonTest) {
 
 // Helper to validate JSON response against provided JSONSchema structure or document
 Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
-  console.log(path);
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
-      path       = typeof args[0] === 'string' && args.shift(),
-      jsonSchema = (typeof args[0] === 'object' || typeof args[0] === 'string') && args.shift();
-      context = (typeof args[0] === 'object') && args.shift();
+      path       = args.shift(),
+      jsonSchema = args.shift();
+      context = args.shift();
 
   var jsVal = new JSONSchemaValidator();
 
@@ -753,7 +752,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   // Convert all other filepaths in context to additonal context
   // for the jsonschema validator to be aware of.
-  if(!_.isUndefined(context)) {
+  if(!_.isUndefined(context) && typeof args[0] === 'object') {
     for (var jsonSchemaSet in context) {
       var jsonSchemaFile = jsonSchemaSet;
       // Allows relative file paths from Frisby specs

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -727,17 +727,12 @@ Frisby.prototype.expectJSON = function(jsonTest) {
 
 
 // Helper to validate JSON response against provided JSONSchema structure or document
-Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_external_required) {
+Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
   var self       = this,
       args       = Array.prototype.slice.call(arguments),
       path       = args.shift(),
-      jsonSchema = args.shift();
+      jsonSchema = args.shift(),
       context = args.shift();
-      disable_external_required = args.shift();
-
-  if(_.isUndefined(disable_external_required)) {
-    disable_external_required = false;
-  }
 
   // Set path value if not set
   if(path == null || path == '' || _.isUndefined(path)) {
@@ -773,11 +768,6 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context, disable_
       }
       var data        = fs.readFileSync(jsonSchemaFullPathToFile, 'utf-8');
       jsonSchema      = JSON.parse(data);
-
-      // Remove required as jsonschema is not able to handle external requires...
-      if (disable_external_required === true) {
-        delete jsonSchema.required;
-      }
       tv4.addSchema(jsonSchemaFile, jsonSchema);
     }
   }

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -752,7 +752,7 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   // Convert all other filepaths in context to additonal context
   // for the jsonschema validator to be aware of.
-  if(!_.isUndefined(context) && typeof args[0] === 'object') {
+  if(!_.isUndefined(context) && typeof context === 'object') {
     for (var jsonSchemaSet in context) {
       var jsonSchemaFile = jsonSchemaSet;
       // Allows relative file paths from Frisby specs
@@ -764,15 +764,17 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
       }
       var data        = fs.readFileSync(jsonSchemaFile, 'utf-8');
       jsonSchema      = JSON.parse(data);
-      // Remove required as jsonschema is not able to handle external requires...
-      delete jsonSchema.required
       jsVal.addSchema(jsonSchemaFile, jsonSchema)
     }
   }
 
   this.current.expects.push(function() {
     var jsonBody = _jsonParse(self.current.response.body);
-    // With path syntax
+    // With path syntax. Send null for the path, not undefined as otherwise it
+    // will pass validaton without actually checking.
+    if(!_.isUndefined(path)) {
+      path = null;
+    }
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
       var res = jsVal.validate(jsonChunk, jsonSchema);
@@ -793,7 +795,6 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   return this;
 };
-
 
 
 // Helper to check parse HTTP response body as JSON and check array or object length

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -725,7 +725,6 @@ Frisby.prototype.expectJSON = function(jsonTest) {
   return this;
 };
 
-
 // Helper to validate JSON response against provided JSONSchema structure or document
 Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
   var self       = this,
@@ -767,8 +766,8 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
         jsonSchemaFullPathToFile = fspath.join(callingDir, context[jsonSchemaSet]);
       }
       var data        = fs.readFileSync(jsonSchemaFullPathToFile, 'utf-8');
-      jsonSchema      = JSON.parse(data);
-      tv4.addSchema(jsonSchemaFile, jsonSchema);
+      jsonSchemaContext      = JSON.parse(data);
+      tv4.addSchema(jsonSchemaFile, jsonSchemaContext);
     }
   }
 

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -777,6 +777,11 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
     _withPath.call(self, path, jsonBody, function(jsonChunk) {
 
       var res = tv4.validateResult(jsonChunk, jsonSchema);
+
+      if (typeof res.missing !== 'undefined' && res.missing.length > 0) {
+        // the array is defined and has at least one element
+        throw new Error("JSONSchema validation failed as the sub-schema " + res.missing[0] + " was not found:");
+      }
       if(res.valid === true) {
         // Use assertion to keep assertion count accurate
         expect(res.valid).toBeTruthy();

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -641,6 +641,7 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
   return this;
 };
 
+
 // Helper to check parse HTTP response body as JSON and check key types
 Frisby.prototype.expectJSON = function(jsonTest) {
   var self     = this,
@@ -793,7 +794,6 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
 
   return this;
 };
-
 
 
 // Helper to check parse HTTP response body as JSON and check array or object length

--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -749,7 +749,11 @@ Frisby.prototype.expectJSONSchema = function(path, jsonSchema, context) {
     jsonSchema      = JSON.parse(data);
   }
 
-  if(context) {
+  if(_.isUndefined(path)) {
+    path = false;
+  }
+
+  if(_.isUndefined(context)) {
     for (var jsonSchemaSet in context) {
       var jsonSchemaFile = jsonSchemaSet;
       // Allows relative file paths from Frisby specs

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "request": ">=2.51",
-    "jsonschema": "1.0.0",
+    "tv4": ">=1.1.*",
     "stack-trace": "0.0.x",
     "mock-request": ">= 0.1.2",
     "nock": "*",

--- a/spec/fixtures/json_schema/decision.json
+++ b/spec/fixtures/json_schema/decision.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Decision",
+    "type": "object",
+    "properties": {
+        "external_id": {
+          "description": "the decision that belongs to the decisionSet",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_-]{1,255}$"
+        },
+        "weight" : {
+          "description": "Weights can be applied to a decision set. Useful when you know the alternative you want to test should not start on a 50/50 basis.",
+          "minimum": "0",
+          "maximum": "100",
+          "multipleOf": 1.0,
+          "type": "number"
+        }
+    },
+    "required": [ "external_id" ]
+}
+
+ 

--- a/spec/fixtures/json_schema/decision_set.json
+++ b/spec/fixtures/json_schema/decision_set.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Decision Set",
+    "type": "object",
+    "properties": {
+        "id": {
+          "description": "Decision Set UID.",
+          "type": "string",
+          "pattern": "^[a-z0-9_-]{1,128}$"
+        },
+        "title": {
+          "description": "Decision Set Title.",
+          "type": "string"
+        },
+        "decisions": {
+          "description": "Decision Set UID.",
+          "type": "array",
+          "minimum": 1,
+          "items": {
+            "$ref": "decision.json"
+          }
+        },
+        "created": {
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+          "type": "string",
+          "format": "date-time"
+        }
+    },
+    "required": [ "id", "title", "decisions", "created" ]
+}

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -25,7 +25,7 @@ nock('http://example.com', { allowUnmocked: false })
   .get('/response_x')
   .reply(200, {
     response: {
-      data: {
+      "data": {
         "id_x": 1,
         "name_x": "A green door",
         "price_x": 12.50,
@@ -33,23 +33,21 @@ nock('http://example.com', { allowUnmocked: false })
       }
     }
   })
-  .get('/response_x')
+  .get('/response_ds')
   .reply(200, {
-    response: {
-       "id":"test_ds",
-       "title":"test_title_ds",
-       "decisions":[
-          {
-             "external_id":"some_identifier",
-             "weight":44
-          },
-          {
-             "external_id":"another_identifier",
-             "weight":25
-          }
-       ],
-       "created":"2885-08-12T16:53:12.206Z"
-    }
+    "id":"test_ds",
+    "title":"test_title_ds",
+    "decisions":[
+      {
+         "external_id":"some_identifier",
+         "weight":44
+      },
+      {
+         "external_id":"another_identifier",
+         "weight":25
+      }
+    ],
+    "created":"2885-08-12T16:53:12.206Z"
   })
   .get('/response-array')
   .reply(200, {
@@ -177,7 +175,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response_x')
       .expectStatus(200)
-      .not().expectJSONSchema('response.data', 'fixtures/json_schema/response1.json')
+      .expectJSONSchema('response.data', 'fixtures/json_schema/response1.json')
     .toss();
   });
 
@@ -185,7 +183,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response_ds')
       .expectStatus(200)
-      .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
+      .expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'}, false)
     .toss();
   });
   
@@ -193,7 +191,15 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response_ds')
       .expectStatus(200)
-      .not().expectJSONSchema('', 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'}, false)
+      .expectJSONSchema('', 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'}, true)
+    .toss();
+  });
+
+  it('should not accept if jsonSchema is invalid', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response_x')
+      .expectStatus(200)
+      .not().expectJSONSchema('', 'fixtures/json_schema/decision_set.json')
     .toss();
   });
 

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -155,11 +155,11 @@ describe('Frisby JSONSchema', function() {
     .toss();
   });
 
-  it('should accept and validate JSONSchema file with jsonPath syntax', function() {
+  it('should accept and validate JSONSchema file with external reference if context was given', function() {
     frisby.create(this.description)
       .get('http://example.com/response_x')
       .expectStatus(200)
-      .not().expectJSONSchema('response.data', 'fixtures/json_schema/response1.json')
+      .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
     .toss();
   });
 });

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -155,6 +155,14 @@ describe('Frisby JSONSchema', function() {
     .toss();
   });
 
+  it('should accept and validate JSONSchema file with jsonPath syntax', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response_x')
+      .expectStatus(200)
+      .not().expectJSONSchema('response.data', 'fixtures/json_schema/response1.json')
+    .toss();
+  });
+
   it('should accept and validate JSONSchema file with external reference if context was given', function() {
     frisby.create(this.description)
       .get('http://example.com/response_x')
@@ -162,4 +170,5 @@ describe('Frisby JSONSchema', function() {
       .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
     .toss();
   });
+
 });

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -67,7 +67,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response1')
       .expectStatus(200)
-      .expectJSONSchema(null, {
+      .expectJSONSchema('', {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "Product",
         "description": "A product from Acme's catalog",

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -185,7 +185,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response_ds')
       .expectStatus(200)
-      .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json', false})
+      .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
     .toss();
   });
   

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -33,6 +33,24 @@ nock('http://example.com', { allowUnmocked: false })
       }
     }
   })
+  .get('/response_x')
+  .reply(200, {
+    response: {
+       "id":"test_ds",
+       "title":"test_title_ds",
+       "decisions":[
+          {
+             "external_id":"some_identifier",
+             "weight":44
+          },
+          {
+             "external_id":"another_identifier",
+             "weight":25
+          }
+       ],
+       "created":"2885-08-12T16:53:12.206Z"
+    }
+  })
   .get('/response-array')
   .reply(200, {
     items: [
@@ -163,11 +181,19 @@ describe('Frisby JSONSchema', function() {
     .toss();
   });
 
-  it('should accept and validate JSONSchema file with external reference if context was given', function() {
+  it('should accept and validate JSONSchema file with external reference if context was given including external required items', function() {
     frisby.create(this.description)
-      .get('http://example.com/response_x')
+      .get('http://example.com/response_ds')
       .expectStatus(200)
-      .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
+      .not().expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json', false})
+    .toss();
+  });
+  
+  it('should accept and validate JSONSchema file with external reference if context was given excluding external required items', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response_ds')
+      .expectStatus(200)
+      .not().expectJSONSchema('', 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'}, false)
     .toss();
   });
 

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -67,7 +67,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response1')
       .expectStatus(200)
-      .expectJSONSchema({
+      .expectJSONSchema(null, {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "Product",
         "description": "A product from Acme's catalog",
@@ -104,7 +104,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response1')
       .expectStatus(200)
-      .expectJSONSchema('fixtures/json_schema/response1.json')
+      .expectJSONSchema(null, 'fixtures/json_schema/response1.json')
     .toss();
   });
 
@@ -112,7 +112,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response1')
       .expectStatus(200)
-      .expectJSONSchema(path.join(__dirname, 'fixtures/json_schema/response1.json'))
+      .expectJSONSchema(null, path.join(__dirname, 'fixtures/json_schema/response1.json'))
     .toss();
   });
 

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -183,6 +183,14 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response_ds')
       .expectStatus(200)
+      .expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { '/decision.json' : 'fixtures/json_schema/decision_set.json'})
+    .toss();
+  });
+
+  it('should not accept if the schema was not found', function() {
+    frisby.create(this.description)
+      .get('http://example.com/response_ds')
+      .expectStatus(200)
       .expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
     .toss();
   });

--- a/spec/frisby_json_schema_spec.js
+++ b/spec/frisby_json_schema_spec.js
@@ -183,15 +183,7 @@ describe('Frisby JSONSchema', function() {
     frisby.create(this.description)
       .get('http://example.com/response_ds')
       .expectStatus(200)
-      .expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'}, false)
-    .toss();
-  });
-  
-  it('should accept and validate JSONSchema file with external reference if context was given excluding external required items', function() {
-    frisby.create(this.description)
-      .get('http://example.com/response_ds')
-      .expectStatus(200)
-      .expectJSONSchema('', 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'}, true)
+      .expectJSONSchema(null, 'fixtures/json_schema/decision_set.json', { 'decision.json' : 'fixtures/json_schema/decision_set.json'})
     .toss();
   });
 


### PR DESCRIPTION
The problem currently, as mentioned in https://github.com/vlucas/frisby/issues/100 is that frisby does not support external json schemas to be loaded in dynamically if it was refered to by another schema.

the jsonschema node library supports this usecase, but only when it is present in memory, as it is not loading in files. This PR changes the behavior of the function call to accept a context array with a list of files to include.

The jsonschema node library does NOT support the require word for external schemas. I replaced this with the tv4 library and all tests are passing now.

Can be used as follows:

```
decision_set_id = uuid.v4();
external_id_1 = uuid.v4();
external_id_2 = uuid.v4();
frisby.create('Create a Decision Set')
.post(host + ':' + port + '/decision_sets?client_id=test', {
"id": "decisionsetid",
"title": "button",
"decisions": [{
"external_id": external_id_1,
"weight": 1
},
{
"external_id": external_id_2,
"weight": 1
}]
}, { json: true })
.expectStatus(200)
.expectHeaderContains('content-type', 'application/json')
.expectJSONSchema('../../doc/raml/api/schemas/decision_set.json', {"decision.json" : '../../doc/raml/api/schemas/decision.json'})
.toss();
```

In this example, the main schema has a reference to the decision.json. This is being replaced by the content of the value of that said key. This can be repeated with many js files.
