### PR TITLE
fix for issue 259.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -387,7 +387,10 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
   if (data) {
     // if JSON data
     if(outgoing.json) {
-      outgoing.headers['content-type'] = 'application/json';
+      //Set default value only if undefined. Do not override if user provides content-type
+      if(_.isUndefined(outgoing.headers['content-type'])) {
+        outgoing.headers['content-type'] = 'application/json';
+      }
       outgoing.body = data;
     } else if(!outgoing.body) {
       if(data instanceof Buffer) {


### PR DESCRIPTION
Set default value for content-type only if undefined.
Do not override if user provides content-type.