### PR TITLE
#122 - Fixed HTTP Headers case issues.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -146,7 +146,7 @@ function Frisby(msg) {
   if(_gs.request && _gs.request.headers) {
     var _tmpHeaders = {};
     _.each(_gs.request.headers, function(val, key) {
-      _tmpHeaders[(key+"").toLowerCase()] = val+"";
+      _tmpHeaders[(key+"")] = val+"";
     });
     _gs.request.headers = _tmpHeaders;
   }
@@ -232,7 +232,7 @@ Frisby.prototype.not = function() {
 // @param string header value content
 //
 Frisby.prototype.addHeader = function(header, content) {
-  this.current.request.headers[(header+"").toLowerCase()] = content+"";
+  this.current.request.headers[(header+"")] = content+"";
   return this;
 };
 
@@ -257,7 +257,7 @@ Frisby.prototype.setHeaders = function(headers) {
 // @param string header key
 //
 Frisby.prototype.removeHeader = function (key) {
-  delete this.current.request.headers[(key+"").toLowerCase()];
+  delete this.current.request.headers[(key+"")];
   return this;
 };
 
@@ -445,7 +445,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
       var headers = {};
       if(res) {
         _.each(res.headers, function(val, key) {
-          headers[(key+"").toLowerCase()] = val;
+          headers[(key+"")] = val;
         });
       }
       // Store relevant current response parts


### PR DESCRIPTION
This issue causes problems with PHP's Authorization header which it expects to be 'Authorization', if it is not that exact case then it will not be handled correctly by PHP in to $_SERVER and thus causing authentication to my API to fail.  I have left the toLowerCase() in places where comparisons are being done (expectsHeader, etc) but in the usage of the headers the case remains as input by the user.
