### PR TITLE
Fix multipart/form-data Advanced use-case issue.

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -470,6 +470,7 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
     // Handle forms (normal data with {form: true} in params options)
     if(!_.isUndefined(params.form) && params.form === true) {
       delete outgoing.headers['content-type'];
+      delete outgoing.body;
       req = runner(outgoing, runCallback);
       var form = req.form();
       for(var field in data) {


### PR DESCRIPTION
```
frisby.create('POST multipart Test')
.post('http://service.com/upload', {
  my_field: my_value,
  custom_file: fs.createReadStream(__dirname + '/unicycle.jpg')
}, { form: true })
.toss();
```

In this case, exists outgoing.body. Therefore cannot post multipart.
So, delete outgoing.body.

please see
https://www.npmjs.com/package/request#multipartform-data-multipart-form-uploads
For advanced cases
