### PR TITLE
Allow HTTP methods to accept both encooded / decoded URLs with multibyte chracters

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -357,6 +357,9 @@ Frisby.prototype._request = function (/* method [uri, data, params] */) {
         headers: {}
       };
 
+  // Automatically encode multibyte characters
+  uri = encodeURI(uri);
+
   // Explicit setting of 'body' param overrides data
   if(params.body) {
     data = params.body;

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -143,4 +143,9 @@ describe('Frisby object setup', function() {
     }).current.outgoing.inspectOnFailure).toEqual(false);
   });
 
+  it('should have an encoded baseUri against request with a decoded uri', function() {
+    expect(frisby.create('mytest-not encoded').get('http://user@example.com:1234/multibyte文字/included').current.outgoing.uri)
+      .toEqual(encodeURI('http://user@example.com:1234/multibyte文字/included'));
+  });
+
 });

--- a/spec/frisby_global_spec.js
+++ b/spec/frisby_global_spec.js
@@ -143,7 +143,7 @@ describe('Frisby object setup', function() {
     }).current.outgoing.inspectOnFailure).toEqual(false);
   });
 
-  it('should have an encoded baseUri against request with a decoded uri', function() {
+  it('should accept both encoded/decoded multibyte urls', function() {
     expect(frisby.create('mytest-not encoded').get('http://user@example.com:1234/multibyte文字/included').current.outgoing.uri)
       .toEqual(encodeURI('http://user@example.com:1234/multibyte文字/included'));
   });


### PR DESCRIPTION
Hi,
I request a patch to allow `frisby.create('test').get` to accept  both encooded / decoded URLs with multibyte characters as an argument.
It might be good for the developers treat such languages or characters :)

(old)
[inacceptable] http://example.com/文字
[acceptable] http://example.com/%E6%96%87%E5%AD%97

(new)
[acceptable] http://example.com/文字
[acceptable] http://example.com/%E6%96%87%E5%AD%97
