### PR TITLE
Fix then chaining

### DIFF
--- a/spec/frisby_spec.js
+++ b/spec/frisby_spec.js
@@ -107,7 +107,7 @@ describe('Frisby', function() {
         mocks.use(['getUser1WithDelay']);
 
         return frisby.get(testHost + '/users/1')
-          .expect('jsonContains', { id: 2 });
+          .expect('jsonContains', { id: 1 });
       })
       .then(function (user1) {
         expect(user1.id).toBe(1);

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -185,7 +185,7 @@ class FrisbySpec {
     }
 
     this._ensureHasFetched();
-    this._fetch.then((responseBody) => {
+    this._fetch = this._fetch.then((responseBody) => {
       let result;
 
       if (this._lastResult && (this._lastResult instanceof FrisbySpec || this._lastResult instanceof Promise)) {


### PR DESCRIPTION
Chained then calls were not behaving as expected. This is exemplified by the typo in spec/frisby_spec.js:110 where the expectation failure is not caught by the test. Corrected the test and chained the calls to then within FrisbySpec