### PR TITLE
Allow params to be passed with get() requests

### DIFF
--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -125,8 +125,8 @@ class FrisbySpec {
   /**
    * GET convenience wrapper
    */
-  get(url) {
-    return this.fetch(url);
+  get(url, params) {
+    return this.fetch(url, params);
   }
 
   /**


### PR DESCRIPTION
The current implementation does not allow the passing of headers, which is crucial for my testing. I simply added a `params` argument to the `get` call, which is directly passed along to `fetch`.