### PR TITLE
Handle multiple headers in response

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -511,8 +511,21 @@ Frisby.prototype.expectHeader = function(_header, content) {
   var self = this;
   var header = (_header+"").toLowerCase();
   this.current.expects.push(function() {
-    if(typeof self.current.response.headers[header] !== "undefined") {
-      expect(self.current.response.headers[header].toLowerCase()).toEqual(content.toLowerCase());
+    headerValue = self.current.response.headers[header]
+    if(typeof headerValue === "string") {
+      expect(headerValue.toLowerCase()).toEqual(content.toLowerCase());
+    } else if(typeof headerValue === "object" && typeof headerValue.length === "number" ) {
+      var anyHeaderMatches = false;
+      for (var headerI = 0; headerI < headerValue.length; ++headerI) {
+        if (headerValue[headerI].toLowerCase() == content.toLowerCase()) {
+          anyHeaderMatches = true;
+        }
+      }
+      if (!anyHeaderMatches && headerValue.length > 0) {  // so that there's a reasonable error message
+        expect(headerValue[0].toLowerCase()).toEqual(content.toLowerCase());
+      } else {
+        expect(anyHeaderMatches).toBe(true);
+      }
     } else {
       throw new Error("Header '" + header + "' not present in HTTP response");
     }
@@ -521,12 +534,25 @@ Frisby.prototype.expectHeader = function(_header, content) {
 };
 
 // HTTP header expect helper (less strict version using 'contains' instead of strict 'equals')
-Frisby.prototype.expectHeaderContains = function(_header, content) {
+Frisby.prototype.expectHeaderContains = function(header, content) {
   var self = this;
-  var header = (_header + "").toLowerCase();
+  var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
-    if(typeof self.current.response.headers[header] !== "undefined") {
-      expect(self.current.response.headers[header].toLowerCase()).toContain(content.toLowerCase());
+    headerValue = self.current.response.headers[header]
+    if(typeof headerValue === "string") {
+      expect(headerValue.toLowerCase()).toContain(content.toLowerCase());
+    } else if(typeof headerValue === "object" && typeof headerValue.length === "number" ) {
+      var anyHeaderMatches = false;
+      for (var headerI = 0; headerI < headerValue.length; ++headerI) {
+        if (headerValue[headerI].toLowerCase().includes(content.toLowerCase())) {
+          anyHeaderMatches = true;
+        }
+      }
+      if (!anyHeaderMatches && headerValue.length > 0) {  // so that there's a reasonable error message
+        expect(headerValue[0].toLowerCase()).toContain(content.toLowerCase());
+      } else {
+        expect(anyHeaderMatches).toBe(true);
+      }
     } else {
       throw new Error("Header '" + header + "' not present in HTTP response");
     }
@@ -535,15 +561,28 @@ Frisby.prototype.expectHeaderContains = function(_header, content) {
 };
 
 // HTTP header expect helper regular expression match
-Frisby.prototype.expectHeaderToMatch = function(_header, pattern) {
+Frisby.prototype.expectHeaderToMatch = function(header, pattern) {
     var self = this;
-    var header = (_header + "").toLowerCase();
+    var header = (header+"").toLowerCase();
     this.current.expects.push(function() {
-        if(typeof self.current.response.headers[header] !== "undefined") {
-            expect(self.current.response.headers[header].toLowerCase()).toMatch(pattern);
-        } else {
-            throw new Error("Header '" + header + "' does not match pattern '" + pattern + "' in HTTP response");
+      headerValue = self.current.response.headers[header]
+      if(typeof headerValue === "string") {
+        expect(headerValue.toLowerCase()).toMatch(pattern);
+      } else if(typeof headerValue === "object" && typeof headerValue.length === "number" ) {
+        var anyHeaderMatches = false;
+        for (var headerI = 0; headerI < headerValue.length; ++headerI) {
+          if (headerValue[headerI].toLowerCase().match(pattern)) {
+            anyHeaderMatches = true;
+          }
         }
+        if (!anyHeaderMatches && headerValue.length > 0) {  // so that there's a reasonable error message
+          expect(headerValue[0].toLowerCase()).toMatch(pattern);
+        } else {
+          expect(anyHeaderMatches).toBe(true);
+        }
+      } else {
+        throw new Error("Header '" + header + "' does not match pattern '" + pattern + "' in HTTP response");
+      }
     });
     return this;
 };


### PR DESCRIPTION
This patches a crash where multiple returned headers are not handled correctly in:

  - expectheader
  - expectHeaderContains
  - expectHeaderToMatch