### PR TITLE
Allow params to be passed with del() requests and rename del() to delete() to be more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install Frisby from NPM into your project:
 ## Creating Tests
 
 Frisby tests start with `frisby` followed by one of `get`, `post`, `put`,
-`delete`, `head`, `fetch`.
+`del`, `head`, `fetch`.
 
 All of the HTTP method conveience methods use `fetch` internally, as Frisby.js is based
 on the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) web standard.

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -153,8 +153,11 @@ class FrisbySpec {
   /**
    * DELETE convenience wrapper
    */
-  del(url) {
-    return this.fetch(url, { method: 'delete' });
+  del(url, params) {
+    params = params || {};
+    params.method = 'delete';
+
+    return this.fetch(url, params);
   }
 
   /**


### PR DESCRIPTION
I needed to be able to pass parameters with delete requests (namely the `Authorization` header in order to authenticate), so I added that functionality.

I also fixed the README that mentioned `delete` instead of `del`.