### PR TITLE
Standardize on 'json' and 'jsonStrict' (types too)

### DIFF
--- a/spec/expects_jsonTypes_spec.js
+++ b/spec/expects_jsonTypes_spec.js
@@ -6,7 +6,7 @@ const mocks = require('./fixtures/http_mocks');
 
 const testHost = 'http://api.example.com';
 
-describe('Frisby expect jsonTypes', function() {
+describe('expect(\'jsonTypes\')', function() {
 
   it('should match exact JSON', function(doneFn) {
     mocks.use(['getUser1']);
@@ -155,6 +155,24 @@ describe('Frisby expect jsonTypes', function() {
         "foo": "bar"
       })
       .expect('jsonTypes', {
+        "name": Joi.string()
+      })
+      .done(doneFn);
+  });
+});
+
+describe('expect(\'jsonTypesStrict\')', function() {
+
+  it('should error on additional JSON keys not accounted for', function (doneFn) {
+    frisby.fromJSON({
+        "name": "john",
+        "foo": "bar"
+      })
+      .expect('jsonTypesStrict', {
+        "name": Joi.string(),
+        "foo": Joi.string()
+      })
+      .expectNot('jsonTypesStrict', {
         "name": Joi.string()
       })
       .done(doneFn);

--- a/spec/expects_json_spec.js
+++ b/spec/expects_json_spec.js
@@ -5,7 +5,7 @@ const mocks = require('./fixtures/http_mocks');
 
 const testHost = 'http://api.example.com';
 
-describe('Frisby expect json', function() {
+describe('expect(\'json\')', function() {
 
   it('should match exact JSON', function(doneFn) {
     mocks.use(['getUser1']);
@@ -23,79 +23,6 @@ describe('Frisby expect json', function() {
 
     frisby.fetch(testHost + '/users/1')
       .expectNot('json', {
-        id: 1,
-        id2: 2,
-        email: 'joe.schmoe@example.com'
-      })
-      .done(doneFn);
-  });
-
-  it('should error with missing key', function(doneFn) {
-    mocks.use(['getUser1']);
-
-    frisby.fetch(testHost + '/users/1')
-      .expectNot('json', {
-        email: 'joe.schmoe@example.com'
-      })
-      .done(doneFn);
-  });
-
-  it('should error with matching keys, but incorrect values', function(doneFn) {
-    mocks.use(['getUser1']);
-
-    frisby.fetch(testHost + '/users/1')
-      .expectNot('json', {
-        id: 1,
-        email: 'joe.schmoe@example.net'
-      })
-      .done(doneFn);
-  });
-
-  it('should match from data via fromJSON', function(doneFn) {
-    frisby.fromJSON({
-        foo: 'bar'
-      })
-      .expect('json', {
-        foo: 'bar'
-      })
-      .done(doneFn);
-  });
-
-  it('should match JSON in using provided path', function(doneFn) {
-    frisby.fromJSON({
-      one: {
-        two: {
-          three: 3
-        }
-      }
-    })
-    .expect('jsonContains', 'one.two', {
-      three: 3
-    })
-      .done(doneFn);
-  });
-
-});
-
-
-describe('Frisby expect jsonContains', function() {
-
-  it('should match exact JSON', function(doneFn) {
-    mocks.use(['getUser1']);
-
-    frisby.fetch(testHost + '/users/1')
-      .expect('jsonContains', {
-        id: 1,
-        email: 'joe.schmoe@example.com'
-      })
-      .done(doneFn);
-  });
-
-  it('should error with extra key', function(doneFn) {
-    mocks.use(['getUser1']);
-
-    frisby.fetch(testHost + '/users/1')
-      .expectNot('jsonContains', {
         id: 1,
         id2: 2,
         email: 'joe.schmoe@example.com'
@@ -107,7 +34,7 @@ describe('Frisby expect jsonContains', function() {
     mocks.use(['getUser1']);
 
     frisby.fetch(testHost + '/users/1')
-      .expect('jsonContains', {
+      .expect('json', {
         email: 'joe.schmoe@example.com'
       })
       .done(doneFn);
@@ -117,7 +44,7 @@ describe('Frisby expect jsonContains', function() {
     mocks.use(['getUser1']);
 
     frisby.fetch(testHost + '/users/1')
-      .expectNot('jsonContains', {
+      .expectNot('json', {
         id: 1,
         email: 'joe.schmoe@example.net'
       })
@@ -129,13 +56,13 @@ describe('Frisby expect jsonContains', function() {
         foo: 'bar',
         bar: 'baz'
       })
-      .expect('jsonContains', {
+      .expect('json', {
         foo: 'bar'
       })
       .done(doneFn);
   });
 
-  it('should error with extra nested keys', function(doneFn) {
+  it('should error with incorrect nested key value', function(doneFn) {
     frisby.fromJSON({
         one: {
           two: {
@@ -143,12 +70,83 @@ describe('Frisby expect jsonContains', function() {
           }
         }
       })
-      .expectNot('jsonContains', {
+      .expectNot('json', {
         one: {
           two: {
             three: 4
           }
         }
+      })
+      .done(doneFn);
+  });
+
+  it('should match JSON content using provided path and object', function(doneFn) {
+    frisby.fromJSON({
+      one: {
+        two: {
+          three: 3
+        }
+      }
+    })
+    .expect('json', 'one.two', {
+      three: 3
+    })
+      .done(doneFn);
+  });
+
+});
+
+describe('expect(\'jsonStrict\')', function() {
+  it('should match exact JSON', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(testHost + '/users/1')
+      .expect('jsonStrict', {
+        id: 1,
+        email: 'joe.schmoe@example.com'
+      })
+      .done(doneFn);
+  });
+
+  it('should error with extra key', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(testHost + '/users/1')
+      .expectNot('jsonStrict', {
+        id: 1,
+        id2: 2,
+        email: 'joe.schmoe@example.com'
+      })
+      .done(doneFn);
+  });
+
+  it('should error with missing key', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(testHost + '/users/1')
+      .expectNot('jsonStrict', {
+        email: 'joe.schmoe@example.com'
+      })
+      .done(doneFn);
+  });
+
+  it('should error with matching keys, but incorrect values', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(testHost + '/users/1')
+      .expectNot('jsonStrict', {
+        id: 1,
+        email: 'joe.schmoe@example.net'
+      })
+      .done(doneFn);
+  });
+
+  it('should match from data via fromJSON', function(doneFn) {
+    frisby.fromJSON({
+        foo: 'bar'
+      })
+      .expect('jsonStrict', {
+        foo: 'bar'
       })
       .done(doneFn);
   });

--- a/spec/frisby_spec.js
+++ b/spec/frisby_spec.js
@@ -75,9 +75,9 @@ describe('Frisby', function() {
     mocks.use(['getUser1', 'getUser2WithDelay']);
 
     frisby.get(testHost + '/users/1')
-      .expect('jsonContains', { id: 1 })
+      .expect('json', { id: 1 })
       .then(frisby.get(testHost + '/users/2')
-          .expect('jsonContains', { id: 2 })
+          .expect('json', { id: 2 })
       )
       .then(function (res) {
         expect(res.json.id).toBe(2);
@@ -89,10 +89,10 @@ describe('Frisby', function() {
     mocks.use(['getUser1', 'getUser2WithDelay']);
 
     frisby.get(testHost + '/users/1')
-      .expect('jsonContains', { id: 1 })
+      .expect('json', { id: 1 })
       .then(function () {
         return frisby.get(testHost + '/users/2')
-          .expect('jsonContains', { id: 2 });
+          .expect('json', { id: 2 });
       })
       .then(function (res) {
         expect(res.json.id).toBe(2);
@@ -104,19 +104,19 @@ describe('Frisby', function() {
     mocks.use(['getUser1', 'getUser2WithDelay']);
 
     frisby.get(testHost + '/users/1')
-      .expect('jsonContains', { id: 1 })
+      .expect('json', { id: 1 })
       .then(function () {
         mocks.use(['getUser1WithDelay']);
 
         return frisby.get(testHost + '/users/1')
-          .expect('jsonContains', { id: 1 });
+          .expect('json', { id: 1 });
       })
       .then(function (res) {
         expect(res.json.id).toBe(1);
       })
       .then(function () {
         return frisby.get(testHost + '/users/2')
-          .expect('jsonContains', { id: 2 });
+          .expect('json', { id: 2 });
       })
       .then(function (res) {
         expect(res.json.id).toBe(2);

--- a/src/frisby.js
+++ b/src/frisby.js
@@ -101,8 +101,20 @@ function removeExpectHandler(expectName, expectFn) {
 }
 
 module.exports = {
+  addExpectHandler,
   baseUrl,
-  del, fetch, fromJSON, get: get, globalSetup, Joi, patch, post, put, setup, timeout, use,
+  del,
+  fetch,
+  fromJSON,
+  get: get,
+  globalSetup,
+  Joi,
+  patch,
+  post,
+  put,
+  removeExpectHandler,
+  setup,
+  timeout,
+  use,
   version,
-  addExpectHandler, removeExpectHandler,
 };

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -64,20 +64,20 @@ const expects = {
 
     incrementAssertionCount();
 
-    utils.withPath(path, response._body, function jsonAssertion(jsonChunk) {
-      assert.deepEqual(json, jsonChunk);
+    utils.withPath(path, response._body, function jsonContainsAssertion(jsonChunk) {
+      let failMsg = "Response [ " + JSON.stringify(jsonChunk) + " ] does not contain provided JSON [ " + JSON.stringify(json) + " ]";
+      assert.ok(_.some([jsonChunk], json), failMsg);
     });
   },
 
-  jsonContains(response, _path, _json) {
+  jsonStrict(response, _path, _json) {
     let json = _json ? _json : _path;
     let path = _json ? _path : false;
 
     incrementAssertionCount();
 
-    utils.withPath(path, response._body, function jsonContainsAssertion(jsonChunk) {
-      let failMsg = "Response [ " + JSON.stringify(jsonChunk) + " ] does not contain provided JSON [ " + JSON.stringify(json) + " ]";
-      assert.ok(_.some([jsonChunk], json), failMsg);
+    utils.withPath(path, response._body, function jsonAssertion(jsonChunk) {
+      assert.deepEqual(json, jsonChunk);
     });
   },
 
@@ -94,7 +94,22 @@ const expects = {
         throw result.error;
       }
     });
-  }
+  },
+
+  jsonTypesStrict(response, _path, _json) {
+    let json = _json ? _json : _path;
+    let path = _json ? _path : false;
+
+    incrementAssertionCount();
+
+    utils.withPath(path, response._body, function jsonTypesAssertion(jsonChunk) {
+      let result = Joi.validate(jsonChunk, json);
+
+      if (result.error) {
+        throw result.error;
+      }
+    });
+  },
 
 };
 


### PR DESCRIPTION
- 'json' is loose (additional keys do not cause errors)
- 'jsonStrict' - additional keys cause errors
- 'jsonTypes' is loose (additional keys do not cause errors)
- 'jsonTypesStrict' - additional keys cause errors


Fixes #365