### PR TITLE
Make it work with URLs which includes multibyte characters

### DIFF
--- a/spec/fixtures/http_mocks.js
+++ b/spec/fixtures/http_mocks.js
@@ -130,6 +130,15 @@ var mocks = {
   },
 
   /**
+   * Multibyte
+   */
+   multibyte() {
+     return nock(mockHost)
+       .get('/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF') // こんにちは
+       .reply(200, 'hello');
+   },
+
+  /**
    * Errors
    */
   timeout() {

--- a/spec/frisby_spec.js
+++ b/spec/frisby_spec.js
@@ -222,4 +222,13 @@ describe('Frisby', function() {
       .expect('status', 200)
       .done(doneFn);
   });
+
+  it('should accept urls which include multibyte characterss', function(doneFn) {
+    mocks.use(['multibyte']);
+
+    // Call path only
+    frisby.fetch(testHost + '/こんにちは')
+      .expect('status', 200)
+      .done(doneFn);
+   });
 });

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -102,7 +102,7 @@ class FrisbySpec {
   }
 
   _formatUrl(url) {
-    let newUrl = url;
+    let newUrl = encodeURI(url);
     let baseUrl = this.getBaseUrl();
 
     // Prepend baseUrl if set, and if URL supplied is a path


### PR DESCRIPTION
Hello.
This PR is revival for #309 .
CJK users sometime use URL with multibyte characters like below.

```
http://example.com/こんにちは
```

Many browsers will automatically encode this URL into below.

```
http://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF` 
```

This PR lets frisby users to use URLs with multibyte characters and improve readability of  CJK user's test codes.