### PR TITLE
Merge setup default headers.

### DIFF
--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -115,7 +115,8 @@ class FrisbySpec {
   }
 
   _fetchParams(params = {}) {
-    let fetchParams = Object.assign({}, this._setupDefaults.request, params);
+    let fetchParams = Object.assign({}, this._setupDefaults.request);
+    _.merge(fetchParams, params);
 
     // Form handling - send correct form headers
     if (params.body instanceof FormData) {


### PR DESCRIPTION
For example in following code:
```
const frisby = require('frisby');

frisby.globalSetup({
  request: {
    headers: {
      Connection: 'Keep-Alive'
    }
  }
});

it('Login', function (done) {
  frisby.post('https://github.com/session', {body: qs.stringify({
    login: 'H1Gdev',
    password: 'XXXXXXXX',
    utf8: '✓'
  }), headers: {
    'Content-Type': 'application/x-www-form-urlencoded',
  }})
  .expect('status', 302)
  .done(done);
});
```

Execute this code, and headers are following.
```
Content-Type: application/x-www-form-urlencoded
```

This PR, and headers are following.
```
Content-Type: application/x-www-form-urlencoded
User-Agent: frisby/2.0.2 (+https://github.com/vlucas/frisby)
Connection: Keep-Alive
```