### PR TITLE
Fix expect header array issue.

### DIFF
--- a/__tests__/expects_spec.js
+++ b/__tests__/expects_spec.js
@@ -63,6 +63,24 @@ describe('Frisby', function() {
       .done(doneFn);
   });
 
+  it('expectHeader should match array header', function(doneFn) {
+    mocks.use(['arrayHeader']);
+
+    frisby.fetch(testHost + '/array-header')
+      .expect('header', 'array', 'one')
+      .expect('header', 'array', /one|two/)
+      .done(doneFn);
+  });
+
+  it('expectHeader should not match array header', function(doneFn) {
+    mocks.use(['arrayHeader']);
+
+    frisby.fetch(testHost + '/array-header')
+      .expectNot('header', 'array', 'three')
+      .expectNot('header', 'array', /three|four/)
+      .done(doneFn);
+  });
+
   it('expectBodyContains should match string', function(doneFn) {
     mocks.use(['getContent']);
 

--- a/__tests__/fixtures/http_mocks.js
+++ b/__tests__/fixtures/http_mocks.js
@@ -124,6 +124,14 @@ const mocks = {
       });
   },
 
+  arrayHeader() {
+    return nock(mockHost)
+      .get('/array-header')
+      .reply(200, 'Array Header.', {
+        array: ['zero', 'one', 'two']
+      });
+  },
+
   /**
    * Cookies
    */

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -39,25 +39,25 @@ const expects = {
 
   header(response, header, headerValue) {
     let headers = response.headers;
-    let responseHeader = headers.get(header);
 
     incrementAssertionCount();
 
-    if (responseHeader) {
-      if (!headerValue) {
-        assert.ok(headers.has(header));
-      } else if (headerValue instanceof RegExp) {
-        // RegExp
-        assert.notEqual(responseHeader.match(headerValue), null, 'Header regex did not match for header ' + header);
-      } else {
-        headerValue = headerValue.toLowerCase();
-        let resHeader = responseHeader.toLowerCase();
+    assert.ok(headers.has(header), `Header '${header}' not present in HTTP response`);
 
+    if (headerValue) {
+      let responseHeader = headers.getAll(header);
+
+      if (headerValue instanceof RegExp) {
+        // RegExp
+        assert.ok(responseHeader.some(function (resHeader) {
+          return headerValue.test(resHeader);
+        }), `Header regex did not match for header '${header}': '${responseHeader}'`);
+      } else {
         // String
-        assert.equal(resHeader, headerValue, `Header value did not match for '${header}': '${resHeader}' !== '${headerValue}'`);
+        assert.ok(responseHeader.some(function (resHeader) {
+          return resHeader.toLowerCase() == headerValue.toLowerCase();
+        }), `Header value '${headerValue}' did not match for header '${header}': '${responseHeader}'`);
       }
-    } else {
-      throw new Error(`Header '${header}' not present in HTTP response`);
     }
   },
 


### PR DESCRIPTION
When header value is array(e.g. 'Set-Cookie'), 'expect header' checks only head of array.

So I check all range of array.