### PR TITLE
Fix call baseUrl and reset globalSetup issue.

### DIFF
--- a/src/frisby.js
+++ b/src/frisby.js
@@ -28,7 +28,7 @@ let _globalSetup = _.cloneDeep(_globalSetupDefaults);
  * Set global base URL for all your frisby tests
  */
 function baseUrl(url) {
-  globalSetup({
+  _.merge(_globalSetup, {
     request: {
       baseUrl: url,
     },


### PR DESCRIPTION
Following code:
```
const frisby = require('frisby');

frisby.globalSetup({
  request: {
    headers: {
      Connection: 'Keep-Alive',
    }
  }
});
frisby.baseUrl('https://github.com/H1Gdev/');
```
Call baseUrl and reset globalSetup.

This PR will merge baseUrl to globalSetup.