### PR TITLE
Fix FrisbySpec timeout issue.

### DIFF
--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -185,6 +185,9 @@ describe('Frisby', function() {
 
     // Test timeout by catching timeout error and running assertions on it
     frisby.timeout(10)
+      .use(function (spec) {
+        expect(spec.timeout()).toBe(10);
+      })
       .fetch(testHost + '/timeout')
       .catch(function (err) {
         expect(err.name).toBe('FetchError');

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -20,7 +20,7 @@ class FrisbySpec {
     this._expects = [];
     this._expectError;
 
-    this._timeout = TIMEOUT_DEFAULT;
+    this._timeout;
     this._setupDefaults = {};
     this._lastResult;
   }
@@ -38,7 +38,6 @@ class FrisbySpec {
    */
   setup(opts, replace) {
     this._setupDefaults = replace ? opts : _.merge(this._setupDefaults, opts);
-    this._timeout = this._setupDefaults.request.timeout || TIMEOUT_DEFAULT;
     return this;
   }
 
@@ -50,11 +49,7 @@ class FrisbySpec {
   timeout(timeout) {
     // GETTER
     if (!timeout) {
-      if (this._setupDefaults.request && this._setupDefaults.request.timeout) {
-        return this._setupDefaults.request.timeout;
-      }
-
-      return this._timeout;
+      return this._timeout || (this._setupDefaults.request && this._setupDefaults.request.timeout) || TIMEOUT_DEFAULT;
     }
 
     // SETTER


### PR DESCRIPTION
Use FrisbySpec timeout() method to set timeout value.
But timeout value is not reflected.

In this PR, timeout value is determined with the following order.

1. this._timeout
2. this._setupDefaults.request.timeout
3. TIMEOUT_DEFAULT