### PR TITLE
Fix do not work with single null value.

### DIFF
--- a/__tests__/expects_json_spec.js
+++ b/__tests__/expects_json_spec.js
@@ -94,6 +94,22 @@ describe('expect(\'json\')', function() {
       .done(doneFn);
   });
 
+  it('should match single value using json', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(testHost + '/users/1')
+      .expect('json', 'id', 1)
+      .done(doneFn);
+  });
+
+  it('should match single null value using json', function(doneFn) {
+    frisby.fromJSON({
+        foo: null
+      })
+      .expect('json', 'foo', null)
+      .done(doneFn);
+  });
+
 });
 
 describe('expect(\'jsonStrict\')', function() {
@@ -155,7 +171,15 @@ describe('expect(\'jsonStrict\')', function() {
     mocks.use(['getUser1']);
 
     frisby.fetch(testHost + '/users/1')
-      .expect('json', 'id', 1)
+      .expect('jsonStrict', 'id', 1)
+      .done(doneFn);
+  });
+
+  it('should match single null value using json', function(doneFn) {
+    frisby.fromJSON({
+        foo: null
+      })
+      .expect('jsonStrict', 'foo', null)
       .done(doneFn);
   });
 

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -62,29 +62,27 @@ const expects = {
   },
 
   json(response, _path, _json) {
-    let json = _json ? _json : _path;
-    let path = _json ? _path : false;
+    let json = _.isUndefined(_json) ? _path : _json;
+    let path = _.isUndefined(_json) ? false : _path;
 
     incrementAssertionCount();
 
     utils.withPath(path, response._body, function jsonContainsAssertion(jsonChunk) {
-      let chunkType = typeof jsonChunk;
       let failMsg = "Response [ " + JSON.stringify(jsonChunk) + " ] does not contain provided JSON [ " + JSON.stringify(json) + " ]";
 
-      // Single value test
-      if (chunkType !== 'object' && chunkType !== 'array') {
+      if (_.isObject(json)) {
+        // Object/aray test
+        assert.ok(_.some([jsonChunk], json), failMsg);
+      } else {
+        // Single value test
         assert.equal(jsonChunk, json);
-        return;
       }
-
-      // Object/aray test
-      assert.ok(_.some([jsonChunk], json), failMsg);
     });
   },
 
   jsonStrict(response, _path, _json) {
-    let json = _json ? _json : _path;
-    let path = _json ? _path : false;
+    let json = _.isUndefined(_json) ? _path : _json;
+    let path = _.isUndefined(_json) ? false : _path;
 
     incrementAssertionCount();
 
@@ -94,8 +92,8 @@ const expects = {
   },
 
   jsonTypes(response, _path, _json) {
-    let json = _json ? _json : _path;
-    let path = _json ? _path : false;
+    let json = _.isUndefined(_json) ? _path : _json;
+    let path = _.isUndefined(_json) ? false : _path;
 
     incrementAssertionCount();
 
@@ -109,8 +107,8 @@ const expects = {
   },
 
   jsonTypesStrict(response, _path, _json) {
-    let json = _json ? _json : _path;
-    let path = _json ? _path : false;
+    let json = _.isUndefined(_json) ? _path : _json;
+    let path = _.isUndefined(_json) ? false : _path;
 
     incrementAssertionCount();
 


### PR DESCRIPTION
Tested single **null** value using following code.

*Test Script*
```javascript
frisby.get(URL)
  .expect('status', 200)
  .expect('json', 'foo', null)
  .expect('jsonStrict', 'foo', null)
  .done(done);
```

*Response JSON body*
```json:
{
  "foo": null
}
```

So, Fixed this issue.
