### PR TITLE
formdata: use request headers along with the form headers

### DIFF
--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -114,7 +114,7 @@ class FrisbySpec {
 
     // Form handling - send correct form headers
     if (params.body instanceof FormData) {
-      fetchParams.headers = fetchParams.body.getHeaders();
+      fetchParams.headers = _.merge(fetchParams.headers, fetchParams.body.getHeaders());
     }
 
     return fetchParams;


### PR DESCRIPTION
For example when passing cookies or Authorization headers, the headers get removed. This PR merges the the original headers and the form headers to fix this.