### PR TITLE
Fix run test expectations before call asynchronous done function.

### DIFF
--- a/__tests__/fixtures/http_mocks.js
+++ b/__tests__/fixtures/http_mocks.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const nock = require('nock');
-const fs = require('fs');
 
 const mockHost = 'http://api.example.com';
 const mocks = {

--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -210,9 +210,9 @@ describe('Frisby', function() {
               'Cookie': cookie1
             }
           })
-          .expect('status', 200)
-          .done(doneFn);
-      });
+          .expect('status', 200);
+      })
+      .done(doneFn);
   });
 
   it('baseUrl sets global baseUrl to be used with all relative URLs', function(doneFn) {

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -294,11 +294,9 @@ class FrisbySpec {
     this._ensureHasFetched();
 
     // Run all expectations
-    this.then(() => {
-      for(let i = 0; i < this._expects.length; i++) {
-        this._expects[i].call(this, this._response);
-      }
-    });
+    for(let i = 0; i < this._expects.length; i++) {
+      this._expects[i].call(this, this._response);
+    }
 
     return this;
   }


### PR DESCRIPTION
call _runExpects() after following code.
```js
    this._fetch.then(() => this._doneFn ? doneFn() : null);
```
(line 251)
Therefore run test expectations after call asynchronous done function.

So run test expectations before call asynchronous done function.