### PR TITLE
Ensure frisby handles 204 w/no body

### DIFF
--- a/__tests__/fixtures/http_mocks.js
+++ b/__tests__/fixtures/http_mocks.js
@@ -97,6 +97,12 @@ const mocks = {
   /**
    * Content
    */
+  noContent() {
+    return nock(mockHost)
+      .get('/contents/none')
+      .reply(204);
+  },
+
   getContent() {
     return nock(mockHost)
       .get('/contents/1')

--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -16,6 +16,25 @@ describe('Frisby', function() {
       .done(doneFn);
   });
 
+  it('should handle a 204 response with no content', function(doneFn) {
+    mocks.use(['noContent']);
+
+    frisby.fetch(testHost + '/contents/none')
+      .expect('status', 204)
+      .done(doneFn);
+  });
+
+  it('should handle a 204 response with no content and then()', function(doneFn) {
+    mocks.use(['noContent']);
+
+    frisby.fetch(testHost + '/contents/none')
+      .expect('status', 204)
+      .then((res) => {
+        expect(res.body).toEqual('');
+      })
+      .done(doneFn);
+  });
+
   it('should support JSON natively', function (doneFn) {
     mocks.use(['createUser2']);
 


### PR DESCRIPTION
Add tests to ensure Frisby works with 204 "No Content" responses (for issue #409)