### PR TITLE
Do not call 'then' method if failed test expectations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node-fetch": "^1.5.2"
   },
   "devDependencies": {
-    "jest": "^20.0.4",
+    "jest": "^21.2.1",
     "nock": "^7.7.2"
   },
   "jest": {

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -274,17 +274,7 @@ class FrisbySpec {
       return this._expectError(err);
     }
 
-    if (typeof fail === 'function') {
-      // If a 'fail' method is provided, use it (Jasmine 2.1+)
-      fail(err);
-    } else if (typeof expect === 'function') {
-      // Hack alert: This is the easiest way I found to fail an async Jasmine
-      // test (ex. in a Promise chain) and still show the full error and stack
-      // trace to the user when 'fail' is not provided
-      expect(err.stack).toBeNull();
-    } else {
-      throw err;
-    }
+    throw err;
   }
 
   /**
@@ -409,7 +399,7 @@ class FrisbySpec {
 
         // Re-throw error if pass is expected; else bury it
         if (expectPass === true) {
-          this._fetchErrorHandler(e);
+          throw e;
         }
       }
 


### PR DESCRIPTION
The following chain test code.
```js
it('frisby chain', function(doneFn) {
  frisby.get('https://github.com/')
    .expect('status', 300)
    .then(function(res) {
      return frisby.get('https://github.com/h1gdev')
        .expect('status', 400);
    })
    .done(doneFn);
});
```

**Result**
```
 FAIL  __tests__/chain2.spec.js (6.45s)
  Chain Test 1
    ? frisby chain (6165ms)

  ● Chain Test 1 ? frisby chain

    AssertionError: HTTP status 300 !== 200

      at FrisbySpec.status (node_modules/frisby/src/frisby/expects.js:25:12)
      at FrisbySpec._addExpect.e (node_modules/frisby/src/frisby/spec.js:406:23)
      at FrisbySpec._runExpects (node_modules/frisby/src/frisby/spec.js:298:24)
      at _fetch.fetch.then.then (node_modules/frisby/src/frisby/spec.js:142:14)
      at process._tickCallback (internal/process/next_tick.js:103:7)

  ● Chain Test 1 ? frisby chain

    AssertionError: HTTP status 400 !== 200

      at FrisbySpec.status (node_modules/frisby/src/frisby/expects.js:25:12)
      at FrisbySpec._addExpect.e (node_modules/frisby/src/frisby/spec.js:406:23)
      at FrisbySpec._runExpects (node_modules/frisby/src/frisby/spec.js:298:24)
      at _fetch.fetch.then.then (node_modules/frisby/src/frisby/spec.js:142:14)
      at process._tickCallback (internal/process/next_tick.js:103:7)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        7.086s
```

Top level expect is failed, but call then function.
I think do not proceed with the test, generally.

**Result(This PR)**
```
 FAIL  __tests__/chain2.spec.js
  Chain Test 1
    ? frisby chain (3026ms)

  ● Chain Test 1 ? frisby chain

    assert.strictEqual(received, expected)

    Expected value to be (operator: ===):
      300
    Received:
      200

    Message:
      HTTP status 300 !== 200

      at FrisbySpec.status (node_modules/frisby/src/frisby/expects.js:25:12)
      at FrisbySpec._addExpect.e (node_modules/frisby/src/frisby/spec.js:396:23)
      at FrisbySpec._runExpects (node_modules/frisby/src/frisby/spec.js:288:24)
      at _fetch.fetch.then.then (node_modules/frisby/src/frisby/spec.js:142:14)
      at process._tickCallback (internal/process/next_tick.js:103:7) thrown

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        4.207s
```