### PR TITLE
Fix "Cannot read property '_expectError' of undefined" issue in fromJSON.

### DIFF
--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -88,7 +88,7 @@ class FrisbySpec {
         this._runExpects();
 
         return responseBody;
-      }).catch(this._fetchErrorHandler);
+      }).catch(this._fetchErrorHandler.bind(this));
 
     return this;
   }


### PR DESCRIPTION
**Test**
```js
const frisby = require('frisby');

it('use fromJSON', function (done) {
  frisby.fromJSON({
    version: frisby.version
  })
    .expect('json', 'version', '1.0.0')
    .done(done);
});
```

_**Expect:**_
```
  ● use fromJSON

    assert.equal(received, expected) or assert(received)

    Expected value to be (operator: ==):
      "1.0.0"
    Received:
      "2.0.7"

      at jsonContainsAssertion (node_modules/frisby/src/frisby/expects.js:78:16)
      at Object.withPath (node_modules/frisby/src/frisby/utils.js:67:12)
      at FrisbySpec.json (node_modules/frisby/src/frisby/expects.js:70:11)
      at FrisbySpec._addExpect.e (node_modules/frisby/src/frisby/spec.js:396:23)
      at FrisbySpec._runExpects (node_modules/frisby/src/frisby/spec.js:288:24)
      at _fetch.fetch.Promise.resolve.then.then (node_modules/frisby/src/frisby/spec.js:88:14) thrown
```

_**Actual:**_
```
  ● use fromJSON

    TypeError: Cannot read property '_expectError' of undefined

      at _fetchErrorHandler (node_modules/frisby/src/frisby/spec.js:274:13)

  console.error console.js:89
    Trace: undefined
        at _fetchErrorHandler (/home/vagrant/works/frisby/test/node_modules/frisby/src/frisby/spec.js:272:13)
```