### PR TITLE
catch method behaves more like native Promise.

### DIFF
--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -299,4 +299,22 @@ describe('Frisby', function() {
     // Restore original FrisbySpec class
     frisby.FrisbySpec = OriginalFrisbySpec;
   });
+
+  it('should use new responseBody when returning another Frisby spec inside catch()', function (doneFn) {
+    mocks.use(['getUser1', 'getUser2WithDelay']);
+
+    frisby.get(testHost + '/users/10')
+      .expect('json', { id: 10 })
+      .then(function (res) {
+        fail('this function will never be called.');
+      })
+      .catch(function (err) {
+        return frisby.get(testHost + '/users/2')
+          .expect('json', { id: 2 });
+      })
+      .then(function (res) {
+        expect(res.json.id).toBe(2);
+      })
+      .done(doneFn);
+  });
 });


### PR DESCRIPTION
**Test**
```js
it('should use new responseBody when returning another Frisby spec inside catch()', function (doneFn) {
  mocks.use(['getUser1', 'getUser2WithDelay']);

  frisby.get(testHost + '/users/10')
    .expect('json', { id: 10 })
    .then(function (res) {
      fail('this function will never be called.');
    })
    .catch(function (err) {
      return frisby.get(testHost + '/users/2')
        .expect('json', { id: 2 });
    })
    .then(function (res) {
      expect(res.json.id).toBe(2);
    })
    .done(doneFn);
});
```
**_Expect:_**

- first then function will never be called.
- If first catch function returns FrisbySpec, test will be continued.

_**Actual:**_

- first then function is called.

**Result**
```
 FAIL  __tests__/frisby_spec.js
  ● Frisby ? should use new responseBody when returning another Frisby spec inside catch()

    Failed: this function will never be called.

      at stackFormatter (node_modules/jest-jasmine2/build/expectation_result_factory.js:49:427)
      at __tests__/frisby_spec.js:309:7
      at _fetch._fetch.then.responseBody (src/frisby/spec.js:231:18)
      at process._tickCallback (internal/process/next_tick.js:103:7)

  ● Frisby ? should use new responseBody when returning another Frisby spec inside catch()

    FetchError: request to http://api.example.com/users/2 failed, reason: Nock: No match for request GET http://api.example.com/users/2

      at OverriddenClientRequest.<anonymous> (node_modules/node-fetch/index.js:133:11)
      at emitOne (events.js:96:13)
      at OverriddenClientRequest.emit (events.js:188:7)
      at node_modules/nock/lib/request_overrider.js:206:11
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```