### PR TITLE
Fix if FrisbySpec is rejected, catch function is not be called issue.

### DIFF
--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -309,6 +309,13 @@ describe('Frisby', function() {
         fail('this function will never be called.');
       })
       .catch(function (err) {
+        return frisby.get(testHost + '/users/1')
+          .expect('json', { id: 10 });
+      })
+      .then(function (res) {
+        fail('this function will never be called.');
+      })
+      .catch(function (err) {
         return frisby.get(testHost + '/users/2')
           .expect('json', { id: 2 });
       })

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -206,21 +206,21 @@ class FrisbySpec {
   /**
    * Chain calls to execute after fetch()
    */
-  then(fn) {
-    if (fn instanceof FrisbySpec) {
-      return fn;
+  then(onFulfilled, onRejected) {
+    if (onFulfilled instanceof FrisbySpec) {
+      return onFulfilled;
     }
 
     this._ensureHasFetched();
     this._fetch = this._fetch.then(response => {
-      let result = fn(response);
+      let result = onFulfilled ? onFulfilled(response) : null;
 
       if (result) {
         return result;
       } else {
         return response;
       }
-    });
+    }, err => onRejected ? onRejected(err) : Promise.reject(err));
     return this;
   }
 
@@ -237,9 +237,9 @@ class FrisbySpec {
   /**
    * Custom error handler (Promise catch)
    */
-  catch(fn) {
+  catch(onRejected) {
     this._ensureHasFetched();
-    this._fetch = this._fetch.catch(err => fn(err));
+    this._fetch = this._fetch.catch(err => onRejected ? onRejected(err) : Promise.reject(err));
     return this;
   }
 


### PR DESCRIPTION
**Test**

```js
  it('should use new responseBody when returning another Frisby spec inside catch()', function (doneFn) {
    mocks.use(['getUser1', 'getUser2WithDelay']);

    frisby.get(testHost + '/users/10')
      .expect('json', { id: 10 })
      .then(function (res) {
        fail('this function will never be called.');
      })
      .catch(function (err) {
        // This FrisbySpec will be rejected.
        return frisby.get(testHost + '/users/1')
          .expect('json', { id: 10 });
      })
      .then(function (res) {
        fail('this function will never be called.');
      })
      .catch(function (err) {
        return frisby.get(testHost + '/users/2')
          .expect('json', { id: 2 });
      })
      .then(function (res) {
        expect(res.json.id).toBe(2);
      })
      .done(doneFn);
  });
```

**_Expect:_**

-  Pass Test.

**_Actual:_**

- Fail Test.
- 2nd catch function is not be called.

**Result**
```
> frisby@2.0.8 test /home/vagrant/works/frisby/frisby
> ./node_modules/jest/bin/jest.js "__tests__/frisby_spec.js"

 FAIL  __tests__/frisby_spec.js
  ● Frisby ? should use new responseBody when returning another Frisby spec inside catch()

    assert.equal(received, expected) or assert(received)

    Expected value to be (operator: ==):
      true
    Received:
      false

    Message:
      Response [ {"id":1,"email":"joe.schmoe@example.com"} ] does not contain provided JSON [ {"id":10} ]

      at jsonContainsAssertion (src/frisby/expects.js:78:16)
      at Object.withPath (src/frisby/utils.js:11:12)
      at FrisbySpec.json (src/frisby/expects.js:70:11)
      at FrisbySpec._addExpect.response (src/frisby/spec.js:368:23)
      at FrisbySpec._runExpects (src/frisby/spec.js:260:24)
      at _fetch.fetch.then.then.responseBody (src/frisby/spec.js:139:12)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7) thrown

Test Suites: 1 failed, 1 total
Tests:       1 failed, 21 passed, 22 total
Snapshots:   0 total
Time:        2.923s, estimated 4s
Ran all test suites matching /__tests__\/frisby_spec.js/i.
npm ERR! Test failed.  See above for more details.
```