### PR TITLE
incrementAssertionCount throws exception "expect is not defined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frisby",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Frisby.js v2.0: REST API Endpoint Testing built on Jasmine",
   "homepage": "http://frisbyjs.com",
   "author": "Vance Lucas <vance@vancelucas.com>",

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -11,7 +11,7 @@ const utils = require('./utils');
  * Jasmine and others
  */
 function incrementAssertionCount() {
-  if (typeof expect != 'undefined' && _.isFunction(expect)) {
+  if (typeof expect !== 'undefined' && _.isFunction(expect)) {
     // Jasmine
     expect(true).toBe(true);
   }

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -11,7 +11,7 @@ const utils = require('./utils');
  * Jasmine and others
  */
 function incrementAssertionCount() {
-  if (_.isFunction(expect)) {
+  if (typeof expect != 'undefined' && _.isFunction(expect)) {
     // Jasmine
     expect(true).toBe(true);
   }


### PR DESCRIPTION
This is the fix for issue #421 

I'm using Frisby to test REST API. I'm replacing [Jest ](https://facebook.github.io/jest/)with [Gauge](https://getgauge.io/contribute.html). It turns out Frisby throws exception if there is no Jasmine `expect` defined. 