### PR TITLE
Fix #428 'Invalid json response body - How to log the server response?' issue.

### DIFF
--- a/__tests__/fixtures/http_mocks.js
+++ b/__tests__/fixtures/http_mocks.js
@@ -223,6 +223,14 @@ const mocks = {
       .reply(400, {
         result: 'error'
       });
+  },
+
+  invalidJSON() {
+    return nock(mockHost)
+      .get('/res/invalid')
+      .reply(200, '{"aaa":}', {
+        'Content-Type': 'application/json'
+      });
   }
 
 };

--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -324,4 +324,19 @@ describe('Frisby', function() {
       })
       .done(doneFn);
   });
+
+  it('should output invalid body and reason in error message', function(doneFn) {
+    mocks.use(['invalidJSON']);
+
+    frisby.get(testHost + '/res/invalid')
+      .then(function (res) {
+        fail('this function will never be called.');
+      })
+      .catch(function (err) {
+        expect(err.message).toMatch(/^Invalid json response /);
+        expect(err.message).toMatch(/body: '.*'/);
+        expect(err.message).toMatch(/reason: '.+'/);
+      })
+      .done(doneFn);
+  });
 });

--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -53,7 +53,7 @@ describe('Frisby', function() {
 
     // Add our custom expect handler
     frisby.addExpectHandler('customUserResponse', function(response) {
-      let json = response._body;
+      let json = response.json;
       expect(json.id).toBe(1);
       expect(json.email).toBe('joe.schmoe@example.com');
     });

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -67,7 +67,7 @@ const expects = {
 
     incrementAssertionCount();
 
-    utils.withPath(path, response._body, function jsonContainsAssertion(jsonChunk) {
+    utils.withPath(path, response.json, function jsonContainsAssertion(jsonChunk) {
       let failMsg = `Response [ ${JSON.stringify(jsonChunk)} ] does not contain provided JSON [ ${JSON.stringify(json)} ]`;
 
       if (_.isArray(json)) {
@@ -89,7 +89,7 @@ const expects = {
 
     incrementAssertionCount();
 
-    utils.withPath(path, response._body, function jsonAssertion(jsonChunk) {
+    utils.withPath(path, response.json, function jsonAssertion(jsonChunk) {
       assert.deepEqual(json, jsonChunk);
     });
   },
@@ -105,7 +105,7 @@ const expects = {
       options.language = { label: path };
     }
 
-    utils.withPath(path, response._body, function jsonTypesAssertion(jsonChunk) {
+    utils.withPath(path, response.json, function jsonTypesAssertion(jsonChunk) {
       let result = Joi.validate(jsonChunk, json, options);
 
       if (result.error) {
@@ -125,7 +125,7 @@ const expects = {
       options.language = { label: path };
     }
 
-    utils.withPath(path, response._body, function jsonTypesAssertion(jsonChunk) {
+    utils.withPath(path, response.json, function jsonTypesAssertion(jsonChunk) {
       let result = Joi.validate(jsonChunk, json, options);
 
       if (result.error) {

--- a/src/frisby/response.js
+++ b/src/frisby/response.js
@@ -18,8 +18,7 @@ class FrisbyResponse {
   }
 
   get json() {
-    // @TODO: Just return body for now, but should check header or something to ensure we actually have a JSON response...
-    return this._body;
+    return this._json;
   }
 }
 

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -75,13 +75,17 @@ class FrisbySpec {
       size: jsonString.length,
       timeout: 0
     });
-    this._response = new FrisbyResponse(fetchResponse);
 
     // Resolve as promise
     this._fetch = fetch.Promise.resolve(fetchResponse)
-      .then(response => response.json())
-      .then(responseBody => {
-        this._response._body = responseBody;
+      .then(response => {
+        this._response = new FrisbyResponse(fetchResponse);
+        return response.text();
+      }).then(responseBody => {
+        let response = this._response;
+        response._body = responseBody;
+        response._json = JSON.parse(responseBody);
+      }).then(() => {
         this._runExpects();
 
         return this._response;
@@ -127,15 +131,19 @@ class FrisbySpec {
     this._fetch = fetch(this._request, { timeout: this.timeout() }) // 'timeout' is a node-fetch option
       .then(response => {
         this._response = new FrisbyResponse(response);
-
-        // Auto-parse JSON
-        if (response.headers.has('Content-Type') && response.headers.get('Content-Type').includes('json') && response.status !== 204) {
-          return response.json();
-        }
-
         return response.text();
       }).then(responseBody => {
-        this._response._body = responseBody;
+        let response = this._response;
+        response._body = responseBody;
+        // Auto-parse JSON
+        if (response.headers.has('Content-Type') && response.headers.get('Content-Type').includes('json') && response.status !== 204) {
+          try {
+            response._json = JSON.parse(responseBody);
+          } catch(e) {
+            return Promise.reject(new TypeError(`Invalid json response body: '${responseBody}' at ${this._request.url} reason: '${e.message}'`));
+          }
+        }
+      }).then(() => {
         this._runExpects();
 
         return this._response;

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -293,7 +293,7 @@ class FrisbySpec {
   }
 
   inspectJSON() {
-    return this.then(() => { this.inspectLog("\nJSON:", JSON.stringify(this._response.body, null, 4)); });
+    return this.then(() => { this.inspectLog("\nJSON:", JSON.stringify(this._response.json, null, 4)); });
   }
 
   inspectStatus() {


### PR DESCRIPTION
Fix #428  issue.

- parse JSON in Frisby.
- Output body if error in parse.

**Response**
```
{"aaa":}
```

**Error message**
```
    TypeError: Invalid json response body: '{"aaa":}' at http://xxx/issue.428 reason: 'Unexpected token } in JSON at position 7'

      at _fetch.fetch.then.then.responseBody (node_modules/frisby/src/frisby/spec.js:143:35)
```