### PR TITLE
Fix #438 'using '*' with jsonTypes is causing false positives on empty arrays' issue.

### DIFF
--- a/__tests__/expects_json_path_spec.js
+++ b/__tests__/expects_json_path_spec.js
@@ -57,6 +57,33 @@ describe('expect(\'json\', <path>, <value>)', function() {
         .expect('json', 'data.?.email', 'joe.schmoe@example.com')
         .done(doneFn);
     });
+
+    it('should error on an empty array (1)', function(doneFn) {
+      frisby.fromJSON([])
+        .expect('json', '*', 1)
+        .catch(function (err) {
+          expect(err.message).toContain("Expected '*' not found");
+        })
+        .done(doneFn);
+    });
+
+    it('should error in an empty array (2)', function(doneFn) {
+      frisby.fromJSON([])
+        .expect('json', '?', 1)
+        .catch(function (err) {
+          expect(err.message).toContain("Expected '?' not found");
+        })
+        .done(doneFn);
+    });
+
+    it('should error in an empty object', function(doneFn) {
+      frisby.fromJSON({})
+        .expect('json', '&', 1)
+        .catch(function (err) {
+          expect(err.message).toContain("Expected '&' not found");
+        })
+        .done(doneFn);
+    });
   });
 
   describe('jsonTypes', function() {

--- a/src/frisby/utils.js
+++ b/src/frisby/utils.js
@@ -38,13 +38,15 @@ function withPath(path, jsonBody, callback) {
           jsonChunks.push(value);
         });
       } else {
-        if (!_.has(jsonChunk, segment)) {
-          throw new Error(`Expected '${segment}' not found (path '${path}')`);
+        if (_.has(jsonChunk, segment)) {
+          jsonChunks.push(_.get(jsonChunk, segment));
         }
-
-        jsonChunks.push(_.get(jsonChunk, segment));
       }
     });
+
+    if (_.isEmpty(jsonChunks)) {
+      throw new Error(`Expected '${segment}' not found (path '${path}')`);
+    }
   });
 
   if ('?' === type) {


### PR DESCRIPTION
Fix #438 issue.

An error occurs if '*', '?', or '&' are empty.
