### PR TITLE
Change HTTP DELETE method to upper case.

### DIFF
--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -185,7 +185,7 @@ class FrisbySpec {
    */
   del(url, params) {
     params = params || {};
-    params.method = 'delete';
+    params.method = 'DELETE';
 
     return this.fetch(url, params);
   }


### PR DESCRIPTION
Only HTTP DELETE method is lowercase letters, so I change it to uppercase letters.