### PR TITLE
Fix #418 - Add 'inspectOnFailure' true by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://frisbyjs.com",
   "author": "Vance Lucas <vance@vancelucas.com>",
   "license": {
-    "type": "BSD"
+    "type": "BSD-3-Clause"
   },
   "repository": {
     "type": "git",

--- a/src/frisby.js
+++ b/src/frisby.js
@@ -19,6 +19,7 @@ const _globalSetupDefaults = {
       'Content-Type': 'application/json',
       'User-Agent': 'frisby/' + version + ' (+https://github.com/vlucas/frisby)',
     },
+    inspectOnFailure: true,
     timeout: 5000,
   },
 };

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -228,7 +228,7 @@ class FrisbySpec {
       } else {
         return response;
       }
-    }, err => onRejected ? onRejected(err) : Promise.reject(err));
+    }, this._handleError(onRejected));
     return this;
   }
 
@@ -247,8 +247,22 @@ class FrisbySpec {
    */
   catch(onRejected) {
     this._ensureHasFetched();
-    this._fetch = this._fetch.catch(err => onRejected ? onRejected(err) : Promise.reject(err));
+    this._fetch = this._fetch.catch(this._handleError(onRejected));
     return this;
+  }
+
+  _handleError(onRejected) {
+    return (err) => {
+      if (onRejected) {
+        return onRejected(err);
+      }
+
+      if (this._setupDefaults.request.inspectOnFailure) {
+        this.inspectLog("\nFAILURE JSON:", JSON.stringify(this._response.json, null, 4));
+      }
+
+      return Promise.reject(err);
+    }
   }
 
   /**
@@ -320,10 +334,8 @@ class FrisbySpec {
     });
   }
 
-  inspectLog() {
-    let params = Array.prototype.slice.call(arguments);
-
-    console.log.apply(null, params); // eslint-disable-line no-console
+  inspectLog(...args) {
+    console.log.call(null, ...args); // eslint-disable-line no-console
     return this;
   }
 


### PR DESCRIPTION
- Adds the v0.8x `inspectOnFailure` feature back into v2
- Makes it enabled by default to provide useful error information in addition to the proper promise rejections