### PR TITLE
Fix Node.js for Windows issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 6.0.0"
   },
   "scripts": {
-    "test": "./node_modules/jest/bin/jest.js"
+    "test": "jest"
   },
   "dependencies": {
     "form-data": "^2.2.0",


### PR DESCRIPTION
On Node.js for Windows a runtime error occurs when `npm test` is executed.
So I fix this issue.