### PR TITLE
Do not output console in test.

### DIFF
--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -121,7 +121,6 @@ describe('Frisby', function() {
         },
         body: 'something something'
       })
-      .inspectBody()
       .expect('status', 200)
       .expect('bodyContains', 'something something')
       .done(doneFn);


### PR DESCRIPTION
It's not a rule...
But only one test outputs console in test.
So do not output console.