### PR TITLE
Provide utils to users.

### DIFF
--- a/src/frisby.js
+++ b/src/frisby.js
@@ -5,6 +5,7 @@ const Joi = require('joi');
 const pkg = require('../package.json');
 const FormData = require('form-data');
 const FrisbySpec = require('./frisby/spec.js');
+const utils = require('./frisby/utils.js');
 
 
 /**
@@ -149,5 +150,6 @@ module.exports = {
   setup,
   timeout,
   use,
+  utils,
   version,
 };


### PR DESCRIPTION
I tried to add custom ExpectHandler to use jsonschema.
If I can not use withPath(), jsonschema will always be checked from the root.
This is very inefficient...

So this PR will provide utils to users.(like Joi.)

Sample code using jsonschema is here.
```js
const frisby = require('frisby');
//const utils = require('frisby/src/frisby/utils');
const Validator = require('jsonschema').Validator; // install jsonschema.

beforeAll(() => {
  frisby.addExpectHandler('jsonschema', (response, path, schema) => {
    frisby.utils.withPath(path, response.json, jsonChunk => { // <- use here.
      let validator = new Validator();
      validator.validate(jsonChunk, schema, { throwError: true });
    });
  });
});

afterAll(() => {
  frisby.removeExpectHandler('jsonschema');
});

describe('Custom Expect Handler', () => {
  it('Using jsonschema', () => {
    return frisby.fromJSON([0, 1, 2, 3, 4])
      .expect('jsonschema', '*', { 'type': 'number'});
  });
});
```
