### PR TITLE
 Fix inspectOnFailure issues.

### DIFF
--- a/__tests__/expects_jsonTypes_spec.js
+++ b/__tests__/expects_jsonTypes_spec.js
@@ -161,9 +161,10 @@ describe('expect(\'jsonTypes\')', function() {
   });
 
   it('should output path in error message (1)', function (doneFn) {
-    frisby.fromJSON({
-      name: 'john'
-    })
+    frisby.setup({ request: { inspectOnFailure: false } })
+      .fromJSON({
+        name: 'john'
+      })
       .expect('jsonTypes', 'name', Joi.number())
       .catch(function (err) {
         expect(err.message).toMatch(/\bname\b/);
@@ -173,11 +174,12 @@ describe('expect(\'jsonTypes\')', function() {
   });
 
   it('should output path in error message (2)', function (doneFn) {
-    frisby.fromJSON({
-      user: {
-        name: 'john'
-      }
-    })
+    frisby.setup({ request: { inspectOnFailure: false } })
+      .fromJSON({
+        user: {
+          name: 'john'
+        }
+      })
       .expect('jsonTypes', 'user.name', Joi.number())
       .catch(function (err) {
         expect(err.message).toMatch(/\buser\.name\b/);
@@ -187,7 +189,8 @@ describe('expect(\'jsonTypes\')', function() {
   });
 
   it('should output default label in error message', function (doneFn) {
-    frisby.fromJSON('john')
+    frisby.setup({ request: { inspectOnFailure: false } })
+      .fromJSON('john')
       .expect('jsonTypes', Joi.number())
       .catch(function (err) {
         expect(err.message).toMatch(/\bvalue\b/);

--- a/__tests__/expects_json_path_spec.js
+++ b/__tests__/expects_json_path_spec.js
@@ -59,7 +59,8 @@ describe('expect(\'json\', <path>, <value>)', function() {
     });
 
     it('should error on an empty array (1)', function(doneFn) {
-      frisby.fromJSON([])
+      frisby.setup({ request: { inspectOnFailure: false } })
+        .fromJSON([])
         .expect('json', '*', 1)
         .catch(function (err) {
           expect(err.message).toContain("Expected '*' not found");
@@ -68,7 +69,8 @@ describe('expect(\'json\', <path>, <value>)', function() {
     });
 
     it('should error in an empty array (2)', function(doneFn) {
-      frisby.fromJSON([])
+      frisby.setup({ request: { inspectOnFailure: false } })
+        .fromJSON([])
         .expect('json', '?', 1)
         .catch(function (err) {
           expect(err.message).toContain("Expected '?' not found");
@@ -77,7 +79,8 @@ describe('expect(\'json\', <path>, <value>)', function() {
     });
 
     it('should error in an empty object', function(doneFn) {
-      frisby.fromJSON({})
+      frisby.setup({ request: { inspectOnFailure: false } })
+        .fromJSON({})
         .expect('json', '&', 1)
         .catch(function (err) {
           expect(err.message).toContain("Expected '&' not found");

--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -346,7 +346,8 @@ describe('Frisby', function() {
       .catch(function (err) {
         expect(err.name).toContain('FetchError');
 
-        return frisby.get(testHost + '/users/1')
+        return frisby.setup({ request: { inspectOnFailure: false } })
+          .get(testHost + '/users/1')
           .expect('json', { id: 10 });
       })
       .then(function (res) {

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -76,7 +76,7 @@ class FrisbySpec {
     });
 
     // Resolve as promise
-    this._fetch = fetch.Promise.resolve(fetchResponse)
+    this._fetch = Promise.resolve(fetchResponse)
       .then(response => {
         this._response = new FrisbyResponse(fetchResponse);
         return response.text();
@@ -138,7 +138,7 @@ class FrisbySpec {
           try {
             response._json = JSON.parse(responseBody);
           } catch(e) {
-            return fetch.Promise.reject(new TypeError(`Invalid json response body: '${responseBody}' at ${this._request.url} reason: '${e.message}'`));
+            return Promise.reject(new TypeError(`Invalid json response body: '${responseBody}' at ${this._request.url} reason: '${e.message}'`));
           }
         }
         return response;
@@ -220,7 +220,7 @@ class FrisbySpec {
       } else {
         return response;
       }
-    }, err => onRejected ? onRejected(err) : fetch.Promise.reject(err));
+    }, err => onRejected ? onRejected(err) : Promise.reject(err));
     return this;
   }
 
@@ -239,7 +239,7 @@ class FrisbySpec {
    */
   catch(onRejected) {
     this._ensureHasFetched();
-    this._fetch = this._fetch.catch(err => onRejected ? onRejected(err) : fetch.Promise.reject(err));
+    this._fetch = this._fetch.catch(err => onRejected ? onRejected(err) : Promise.reject(err));
     return this;
   }
 


### PR DESCRIPTION
- inspectOnFailure is not output.

**sample code**
```js
it('should be a teapot', () => {
  return frisby.get('http://httpbin.org/status/418')
    .expect('status', 200);
});
```

**_Expect:_**
```
  ● Console

    console.log src/frisby/spec.js:302

      FAILURE Status: 418
      Body:
          -=[ teapot ]=-

             _...._
           .'  _ _ `.
          | ."` ^ `". _,
          \_;`"---"`|//
            |       ;/
            \_     _/
              `"""`
```

**_Actual:_**
inspectOnFailure is not output.

- too many inspectOnFailures is output.

**sample code**
```js
it('should be a teapot', () => {
  return frisby.get('http://httpbin.org/status/418')
    .expect('status', 200)
    .expect('status', 418)
    .expect('status', 418);
});
```

**_Expect:_**
```
   ● Console

   console.log src/frisby/spec.js:302

      FAILURE Status: 418
      Body:
          -=[ teapot ]=-

             _...._
           .'  _ _ `.
          | ."` ^ `". _,
          \_;`"---"`|//
            |       ;/
            \_     _/
              `"""`
```


**_Actual:_**
```
  ● Console

    console.log src/frisby/spec.js:323

      FAILURE Body:
          -=[ teapot ]=-

             _...._
           .'  _ _ `.
          | ."` ^ `". _,
          \_;`"---"`|//
            |       ;/
            \_     _/
              `"""`

    console.log src/frisby/spec.js:323

      FAILURE Body:
          -=[ teapot ]=-

             _...._
           .'  _ _ `.
          | ."` ^ `". _,
          \_;`"---"`|//
            |       ;/
            \_     _/
              `"""`
```