### PR TITLE
Fix #493 'Override Content-Type, specifically when uploading file/posting FormData' issue.

### DIFF
--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -110,14 +110,14 @@ class FrisbySpec {
   }
 
   _fetchParams(params = {}) {
-    let fetchParams = _.merge({}, this._setupDefaults.request, params);
+    let fetchParams = _.cloneDeep(this._setupDefaults.request);
 
     // Form handling - send correct form headers
     if (params.body instanceof FormData) {
-      fetchParams.headers = _.merge(fetchParams.headers, fetchParams.body.getHeaders());
+      delete fetchParams.headers['Content-Type'];
     }
 
-    return fetchParams;
+    return _.merge(fetchParams, params);
   }
 
   /**


### PR DESCRIPTION
If `Content-Type` not exist, node-fetch decides appropriate `Content-Type` from form-data.
So if body is form-data then delete `Content-Type` from headers.