### PR TITLE
Allow special characters * and ? to be used for object values.

### DIFF
--- a/__tests__/expects_jsonTypes_spec.js
+++ b/__tests__/expects_jsonTypes_spec.js
@@ -143,6 +143,7 @@ describe('expect(\'jsonTypes\')', function() {
     frisby.fromJSON({
       offers: [{name: 'offer1'}, {name: 'offer2'}]
     })
+      .expect('jsonTypes', 'offers', Joi.array())
       .expect('jsonTypes', 'offers.*', {
         name: Joi.string()
       })

--- a/__tests__/expects_json_path_spec.js
+++ b/__tests__/expects_json_path_spec.js
@@ -58,6 +58,25 @@ describe('expect(\'json\', <path>, <value>)', function() {
         .done(doneFn);
     });
 
+    it('should test one of the values in an object', function(doneFn) {
+      mocks.use(['getUsersName']);
+
+      frisby.fetch(testHost + '/users.name')
+        .expect('json', 'data.?', {
+          id: 1,
+          email: 'joe.schmoe@example.com'
+        })
+        .done(doneFn);
+    });
+
+    it('should test one of the values in an object for a single field', function(doneFn) {
+      mocks.use(['getUsersName']);
+
+      frisby.fetch(testHost + '/users.name')
+        .expect('json', 'data.?.email', 'joe.schmoe@example.com')
+        .done(doneFn);
+    });
+
     it('should error on an empty array (1)', function(doneFn) {
       frisby.setup({ request: { inspectOnFailure: false } })
         .fromJSON([])
@@ -125,6 +144,25 @@ describe('expect(\'json\', <path>, <value>)', function() {
 
       frisby.fetch(testHost + '/users.name')
         .expect('jsonTypes', 'data.&.id', Joi.number())
+        .done(doneFn);
+    });
+
+    it('should test every object in an object (2)', function(doneFn) {
+      mocks.use(['getUsersName']);
+
+      frisby.fetch(testHost + '/users.name')
+        .expect('jsonTypes', 'data.*', {
+          id: Joi.number(),
+          email: Joi.string().email()
+        })
+        .done(doneFn);
+    });
+
+    it('should test every object in an object for a single value (2)', function(doneFn) {
+      mocks.use(['getUsersName']);
+
+      frisby.fetch(testHost + '/users.name')
+        .expect('jsonTypes', 'data.*.id', Joi.number())
         .done(doneFn);
     });
   });

--- a/src/frisby/utils.js
+++ b/src/frisby/utils.js
@@ -15,22 +15,10 @@ function withPath(path, jsonBody, callback) {
   // Use given path to check deep objects
   _.each(_.toPath(path), segment => {
     _.each(jsonChunks.splice(0), jsonChunk => {
-      let jt = typeof jsonChunk;
-
-      if ('*' === segment || '?' === segment) {
-        // Must be array if special characters are present
-        if (!_.isArray(jsonChunk)) {
-          throw new TypeError(`Expected '${path}' to be Array (got '${jt}' from JSON response)`);
-        }
-
-        type = segment;
-        _.each(jsonChunk, value => {
-          jsonChunks.push(value);
-        });
-      } else if ('&' === segment) {
+      if (_.includes(['*', '?', '&'], segment)) {
         // Must be object if special character is present
         if (!_.isObject(jsonChunk)) {
-          throw new TypeError(`Expected '${path}' to be Object (got '${jt}' from JSON response)`);
+          throw new TypeError(`Expected '${path}' to be Object (got '${typeof jsonChunk}' from JSON response)`);
         }
 
         type = segment;
@@ -50,7 +38,7 @@ function withPath(path, jsonBody, callback) {
   });
 
   if ('?' === type) {
-    // ONE item in array should match
+    // ONE item in object and array should match
     let itemCount = jsonChunks.length;
     let errorCount = 0;
     let errorLast;
@@ -69,7 +57,7 @@ function withPath(path, jsonBody, callback) {
       throw errorLast || new Error(`Expected one object in path '${path}' to match provided JSON values`);
     }
   } else {
-    // EACH item in array should match
+    // EACH item in object and array should match
     // Normal matcher
     _.each(jsonChunks, jsonChunk => {
       callback(jsonChunk);


### PR DESCRIPTION
I have the following questions about special characters of path at PR #498.
- Is there no **?** for object ?
- Is it necessary to strictly separate array and object ?

So I create PR that allows special characters **\*** and **?** to be used for object values.
This PR makes **\*** and **&** equal, but exists **&** for backward compatibility.
