### PR TITLE
Allow `then()` to be called without `fetch()`.

### DIFF
--- a/__tests__/fixtures/http_mocks.js
+++ b/__tests__/fixtures/http_mocks.js
@@ -264,7 +264,13 @@ const mocks = {
       .reply(200, '{"aaa":}', {
         'Content-Type': 'application/json'
       });
-  }
+  },
+
+  networkError() {
+    return nock(mockHost)
+      .get('/bad-network')
+      .replyWithError('Network failed.');
+  },
 
 };
 

--- a/__tests__/interactions_with_async.js
+++ b/__tests__/interactions_with_async.js
@@ -1,0 +1,79 @@
+'use strict';
+const assert = require('assert');
+const frisby = require('../src/frisby');
+const mocks = require('./fixtures/http_mocks');
+
+const testHost = 'http://api.example.com';
+
+describe('Frisby async interactions', function () {
+  it('should resolve with response upon then()', function (done) {
+    mocks.use(['getUser1']);
+
+    frisby.get(testHost + '/users/1')
+      .then((res) => {
+        assert.equal(res.status, 200);
+        assert.equal(res.body, '{"id":1,"email":"joe.schmoe@example.com"}');
+
+        done();
+      });
+  });
+
+  it('should call with nothing the callback passed to done()', function (done) {
+    mocks.use(['getUser1']);
+
+    frisby.get(testHost + '/users/1')
+      .done(function () {
+        assert.equal(arguments.length, 0);
+
+        done();
+      });
+  });
+
+  it('should resolve with error upon then()', function (done) {
+    mocks.use(['networkError']);
+
+    frisby.get(testHost + '/bad-network')
+      .then(() => {
+        assert.fail('Should have failed.');
+        done();
+      }, (err) => {
+        assert(err.message.includes('Network failed.'));
+        done();
+      });
+  });
+
+  it('should resolve with error upon catch()', function (done) {
+    mocks.use(['networkError']);
+
+    frisby.get(testHost + '/bad-network')
+      .catch((err) => {
+        assert(err.message.includes('Network failed.'));
+        done();
+      });
+  });
+
+  it('should resolve with spec upon then(), no fetch()', function (done) {
+    frisby.setup({})
+      .then((spec) => {
+        assert(spec instanceof frisby.FrisbySpec);
+
+        done();
+      });
+  });
+
+  it('should throw upon done() without fetch()', function (done) {
+    assert.throws(() => {
+      frisby.setup().done();
+
+      done();
+    });
+  });
+
+  it('should throw upon catch() without fetch()', function (done) {
+    assert.throws(() => {
+      frisby.setup().done();
+
+      done();
+    });
+  });
+});

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -226,16 +226,20 @@ class FrisbySpec {
       return onFulfilled;
     }
 
-    this._ensureHasFetched();
-    this._fetch = this._fetch.then(response => {
-      let result = onFulfilled ? onFulfilled(response) : null;
+    if (this._fetch) {
+      this._fetch = this._fetch.then(response => {
+        let result = onFulfilled ? onFulfilled(response) : null;
 
-      if (result) {
-        return result;
-      } else {
-        return response;
-      }
-    }, err => onRejected ? onRejected(err) : Promise.reject(err));
+        if (result) {
+          return result;
+        } else {
+          return response;
+        }
+      }, err => onRejected ? onRejected(err) : Promise.reject(err));
+    } else {
+      onFulfilled(this);
+    }
+
     return this;
   }
 


### PR DESCRIPTION
Previously, calling `then()` on a spec without calling `fetch()` first threw an error; preventing, say, returning a `FrisbySpec` from an `async` function.

This change allows `then()` to be called, explicitly resolving with the `FrisbySpec` instead of attempting to make a request.

I didn't notice documentation that needed to be updated, but this change includes tests for the described behaviour. (There wasn't a suite for this _category_ of behaviour, async interactions, so I created one.) I apologize for not discussing the changes first; I'd be delighted to talk through the design and why I feel this is useful, and will not be offended if you tell me this is outside of the scope of Frisby.