### PR TITLE
FrisbySpec supports finally().

### DIFF
--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -407,4 +407,14 @@ describe('Frisby', function() {
       })
       .done(doneFn);
   });
+
+  it('Test FrisbySpec finally', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(testHost + '/users/1')
+      .expect('status', 200)
+      .finally(() => {
+      })
+      .done(doneFn);
+  });
 });

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -261,6 +261,15 @@ class FrisbySpec {
   }
 
   /**
+   * Custom finally handler (Promise finally)
+   */
+  finally(onFinally) {
+    this._ensureHasFetched();
+    this._fetch = this._fetch.finally(() => onFinally ? onFinally() : undefined);
+    return this;
+  }
+
+  /**
    * Return internal promise used by Frisby.js
    * Note: Using this will break the chainability of Frisby.js method calls
    */

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -265,7 +265,20 @@ class FrisbySpec {
    */
   finally(onFinally) {
     this._ensureHasFetched();
-    this._fetch = this._fetch.finally(() => onFinally ? onFinally() : undefined);
+    if (_.isFunction(this._fetch.finally)) {
+      this._fetch = this._fetch.finally(() => onFinally ? onFinally() : undefined);
+    } else {
+      // Return Promise.reject from finally handler is not supported.
+      this._fetch = this._fetch.then(value => {
+        if (onFinally)
+          onFinally();
+        return value;
+      }, reason => {
+        if (onFinally)
+          onFinally();
+        return Promise.reject(reason);
+      });
+    }
     return this;
   }
 


### PR DESCRIPTION
FrisbySpec supports Promise.finally().