### PR TITLE
Fix test jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "encoding": "^0.1.12"
   },
   "devDependencies": {
-    "jest": "^21.2.1",
-    "nock": "^9.3.3",
-    "eslint": "^4.19.1"
+    "eslint": "^4.19.1",
+    "jest": "^24.6.0",
+    "nock": "^9.3.3"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "jest": {
     "testPathIgnorePatterns": [
-      "/__tests__/fixtures/",
+      "<rootDir>/__tests__/fixtures/",
       "/node_modules/",
-      "/src/"
+      "<rootDir>/src/"
     ],
     "verbose": false
   }


### PR DESCRIPTION
Hi. Upgrade jest and fix ignore pattern.

```
$ npm run test

> frisby@2.1.1 test /path/to/frisby
> jest

No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In /path/to/frisby
  17 files checked.
  testMatch: **/__tests__/**/*.[jt]s?(x), **/?(*.)+(spec|test).[tj]s?(x) - 10 matches
  testPathIgnorePatterns: /__tests__/fixtures/, /node_modules/, /src/ - 0 matches
  testRegex:  - 0 matches
Pattern:  - 0 matches
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! frisby@2.1.1 test: `jest`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the frisby@2.1.1 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/koooge/.npm/_logs/2019-04-02T06_03_18_838Z-debug.log
```

  I could test frisby by `npm test` on my env. `/src/` seems above error, so I replaced with `/src/frisby/spec.js`.