### PR TITLE
Added possibility to measure server response time

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ response of your API.
  * `jsonTypes` - Match JSON structure + value types
  * `jsonTypesStrict` - Match EXACT JSON structure + value types (extra keys not tested for cause test failures)
  * `bodyContains` - Match partial body content (string or regex)
+  * `responseTime` - Check if request completes within a specified duration (ms)
 
 ## Define Custom Expect Handlers
 

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -28,7 +28,6 @@ const expects = {
     );
   },
 
-
   status(response, statusCode) {
     incrementAssertionCount();
 

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -19,6 +19,16 @@ function incrementAssertionCount() {
 
 const expects = {
 
+  responseTime(response, maxResponseTime) {
+    incrementAssertionCount();
+
+    assert.ok(
+      maxResponseTime >= response.responseTime,
+      `Request took longer than ${maxResponseTime}ms: (${response.responseTime}ms).`
+    );
+  },
+
+
   status(response, statusCode) {
     incrementAssertionCount();
 

--- a/src/frisby/response.js
+++ b/src/frisby/response.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 class FrisbyResponse {
   constructor(fetchResponse) {

--- a/src/frisby/response.js
+++ b/src/frisby/response.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 class FrisbyResponse {
   constructor(fetchResponse) {
@@ -19,6 +19,10 @@ class FrisbyResponse {
 
   get json() {
     return this._json;
+  }
+
+  get responseTime() {
+    return this._responseTimeMs;
   }
 }
 

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -79,6 +79,7 @@ class FrisbySpec {
     this._fetch = Promise.resolve(fetchResponse)
       .then(response => {
         this._response = new FrisbyResponse(response);
+        this._response._responseTimeMs = 0;
         return response.text()
           .then(text => {
             let response = this._response;
@@ -129,9 +130,11 @@ class FrisbySpec {
     let fetchParams = this._fetchParams(params);
     this._request = new fetch.Request(this._formatUrl(url, options.urlEncode), fetchParams);
 
+    let requestStartTime = Date.now();
     this._fetch = fetch(this._request, { timeout: this.timeout() }) // 'timeout' is a node-fetch option
       .then(response => {
         this._response = new FrisbyResponse(response);
+        this._response._responseTimeMs = Date.now() - requestStartTime;
         if (this._setupDefaults.request && this._setupDefaults.request.rawBody) {
           return response.arrayBuffer()
             .then(buffer => {


### PR DESCRIPTION
# Summary
Added the possibility to `expect` a maximum response time for a request. This is different to setting the fetch `timeout` value as the timeout will fire both when the target server is unavailable or when the timeout is reached. 

# Usage

```javascript
it('should complete within 500ms', function () {
  return frisby.get('http://httpbin.org/status/200')
    .expect('responseTime', 500);
});
```
**Output:**

```bash
Message:
    AssertionError [ERR_ASSERTION]: Request took longer than 500ms: (654ms).
```