### PR TITLE
feat: Allow comma in regexp

### DIFF
--- a/__tests__/expects_spec.js
+++ b/__tests__/expects_spec.js
@@ -63,6 +63,18 @@ describe('Frisby', function() {
       .done(doneFn);
   });
 
+  it('expectHeader should match comma separated header', function(doneFn) {
+    mocks.use(['options']);
+
+    frisby.options(testHost + '/')
+      .expect('status', 204)
+      .expect('header', 'Access-Control-Allow-Methods', /GET/)
+      .expect('header', 'Access-Control-Allow-Methods', /GET,HEAD,PUT,PATCH,POST,DELETE/)
+      .expect('header', 'Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE')
+      .done(doneFn);
+  });
+
+
   it('expectHeader should match array header', function(doneFn) {
     mocks.use(['arrayHeader']);
 

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -54,18 +54,15 @@ const expects = {
     assert.ok(headers.has(header), `Header '${header}' not present in HTTP response`);
 
     if (headerValue) {
-      let responseHeader = headers.get(header).split(/, */);
+      let responseHeader = headers.get(header);
 
       if (headerValue instanceof RegExp) {
         // RegExp
-        assert.ok(responseHeader.some(function (resHeader) {
-          return headerValue.test(resHeader);
-        }), `Header regex did not match for header '${header}': '${responseHeader}'`);
+        assert.ok(headerValue.test(responseHeader), `Header regex did not match for header '${header}': '${responseHeader}'`);
       } else {
         // String
-        assert.ok(responseHeader.some(function (resHeader) {
-          return resHeader.toLowerCase() == headerValue.toLowerCase();
-        }), `Header value '${headerValue}' did not match for header '${header}': '${responseHeader}'`);
+        const regexp = new RegExp(headerValue);
+        assert.ok(regexp.test(responseHeader), `Header value '${headerValue}' did not match for header '${header}': '${responseHeader}'`);
       }
     }
   },


### PR DESCRIPTION
Hi there.

A csv header like`.expect('header', 'Access-Control-Allow-Methods', /GET,HEAD/)` does not pass the test because the header is splited with comma ['GET', 'HEAD']. But I suppose it should pass the test.

Originally, assert.ok() has failed to expect above like following:
```javascript
/GET,HEAD/'.test('GET'); // false'
/GET,HEAD/'.test('HEAD'); // false'
```