### PR TITLE
chore: Upgrade nock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - node_modules
 
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "jest": "^24.6.0",
-    "nock": "^9.3.3"
+    "nock": "^11.6.0"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "./src/frisby",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Upgrade nock due to warning with node12

```
$ npm run test
(node:86033) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
(node:86032) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
(node:86035) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
```