### PR TITLE
refactor!: Increased version for all dependency to highest non breaking, removed Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - node_modules
 
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "lint": "eslint src/** __tests__/**"
   },
   "dependencies": {
-    "form-data": "^2.2.0",
-    "joi": "^13.0.0",
+    "form-data": "^3.0.0",
+    "@hapi/joi": "^15.1.1",
     "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",
     "encoding": "^0.1.12"

--- a/src/frisby.js
+++ b/src/frisby.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const pkg = require('../package.json');
 const FormData = require('form-data');
 const FrisbySpec = require('./frisby/spec.js');

--- a/src/frisby/expects.js
+++ b/src/frisby/expects.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const _ = require('lodash');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const utils = require('./utils');
 
 /**


### PR DESCRIPTION
When installing the latest version, npm complains about using deprecated versions. I updated each of the deps to the highest version that did not break tests. Also change`joi` to `@hapi/joi`

@vlucas could you review and publish an updated version to npm.