### PR TITLE
Frisby supports URL API.

### DIFF
--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -434,4 +434,14 @@ describe('Frisby', function() {
       .expect('status', 200)
       .done(doneFn);
   });
+
+  it('use Legacy URL API', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    const url = require('url');
+
+    frisby.fetch(url.parse(testHost + '/users/1'))
+      .expect('status', 200)
+      .done(doneFn);
+  });
 });

--- a/__tests__/frisby_spec.js
+++ b/__tests__/frisby_spec.js
@@ -426,4 +426,12 @@ describe('Frisby', function() {
       })
       .done(doneFn);
   });
+
+  it('use WHATWG URL API', function(doneFn) {
+    mocks.use(['getUser1']);
+
+    frisby.fetch(new URL('/users/1', testHost))
+      .expect('status', 200)
+      .done(doneFn);
+  });
 });

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -103,6 +103,8 @@ class FrisbySpec {
   _formatUrl(url, urlEncode = true) {
     let baseUrl = this.getBaseUrl();
     let newUrl = urlEncode && _.isString(url) ? encodeURI(url) : url;
+    // Legacy urlObject cannot be set to URL.
+    newUrl = newUrl.href ? newUrl.href : newUrl;
     return baseUrl ? new URL(newUrl, baseUrl) : new URL(newUrl);
   }
 

--- a/src/frisby/spec.js
+++ b/src/frisby/spec.js
@@ -101,15 +101,9 @@ class FrisbySpec {
   }
 
   _formatUrl(url, urlEncode = true) {
-    let newUrl = urlEncode ? encodeURI(url) : url;
     let baseUrl = this.getBaseUrl();
-
-    // Prepend baseUrl if set, and if URL supplied is a path
-    if (url.startsWith('/') && baseUrl) {
-      newUrl = baseUrl + url;
-    }
-
-    return newUrl;
+    let newUrl = urlEncode && _.isString(url) ? encodeURI(url) : url;
+    return baseUrl ? new URL(newUrl, baseUrl) : new URL(newUrl);
   }
 
   _fetchParams(params = {}) {


### PR DESCRIPTION
https://nodejs.org/dist/latest-v12.x/docs/api/url.html

supports the following.
- WHATWG URL API ([URL class](https://nodejs.org/dist/latest-v12.x/docs/api/url.html#url_class_url))
- Legacy URL API ([urlObject](https://nodejs.org/dist/latest-v12.x/docs/api/url.html#url_legacy_urlobject))