### PR TITLE
chore: Drop node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "./src/frisby",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 14.17.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Drop node 10 and 12 support. They are already EOL and npm@9 does not support them. https://github.com/npm/cli/releases/tag/v9.0.0